### PR TITLE
Add GBIF as a data source, with readme and example notebook.

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,14 @@ AI for Earth and partners have assembled a repository of labeled information rel
 
 * [lila.science](http://lila.science)
 
+## Global Biodiversity Information Facility (GBIF)
+
+Exports of global species occurrence data from the GBIF network.
+
+* [Source](https://www.gbif.org)
+* [Documentation](data/gbif.md)
+* [Notebook](data/gbif.ipynb)
+
 # Legal stuff
 
 ## Contributing

--- a/data/gbif.ipynb
+++ b/data/gbif.ipynb
@@ -1,0 +1,468 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "source": [
+        "# Demo notebook for accessing GBIF data on Azure\n",
+        "\n",
+        "This notebook provides an example of accessing Global Biodiversity Information Facility (GBIF) occurrence data from blob storage on Azure.  Periodic snapshots of the data are stored in Parquet format.\n",
+        "\n",
+        "GBIF occurrence data are stored in the West Europe Azure region, so this notebook will run most efficiently on Azure compute located in West Europe.\n",
+        "We recommend that substantial computation depending on GBIF data also be situated in West Europe.\n",
+        "If you are using GBIF data for environmental science applications, consider applying for an [AI for Earth grant](http://aka.ms/ai4egrants) to support your compute requirements.\n",
+        "\n",
+        "## Imports and constants"
+      ],
+      "metadata": {
+        "nteract": {
+          "transient": {
+            "deleting": false
+          }
+        }
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "%%capture\n",
+        "\n",
+        "!pip install \"dask[complete]\"\n",
+        "!pip install \"adlfs\"\n",
+        "\n",
+        "import dask.dataframe as dd\n",
+        "from adlfs import AzureBlobFileSystem\n",
+        "\n",
+        "storage_account_name = 'ai4edataeuwest'\n",
+        "# TODO: make dataset public\n",
+        "sas_token = REDACTED\n",
+        "folder_name = 'gbif/occurrence'\n"
+      ],
+      "outputs": [],
+      "execution_count": 1,
+      "metadata": {
+        "gather": {
+          "logged": 1618238166691
+        },
+        "jupyter": {
+          "outputs_hidden": true
+        }
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Listing the data files\n",
+        "\n",
+        "GBIF provide an export of occurrence data under the Creative Commons Zero and Creative Commons By-Attribution licenses.  A dataset is uploaded periodically containing georeferenced records available under either license.\n",
+        "\n",
+        "We can use `adlfs` to view the available data exports:"
+      ],
+      "metadata": {
+        "nteract": {
+          "transient": {
+            "deleting": false
+          }
+        }
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "fs = AzureBlobFileSystem(account_name=storage_account_name, sas_token=sas_token)\n",
+        "export_folders = fs.glob(folder_name + '/20*')\n",
+        "print('Found {} GBIF data exports'.format(len(export_folders)))\n",
+        "for k in range(0,len(export_folders)):\n",
+        "    print(export_folders[k])"
+      ],
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Found 1 GBIF data exports\n",
+            "gbif/occurrence/2021-04-13\n"
+          ]
+        }
+      ],
+      "execution_count": 2,
+      "metadata": {
+        "collapsed": true,
+        "jupyter": {
+          "source_hidden": false,
+          "outputs_hidden": false
+        },
+        "nteract": {
+          "transient": {
+            "deleting": false
+          }
+        },
+        "gather": {
+          "logged": 1618319312245
+        }
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "We can then list the files within one of these exports, in this case the last (most recent) one:"
+      ],
+      "metadata": {
+        "nteract": {
+          "transient": {
+            "deleting": false
+          }
+        }
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "data_path = export_folders[-1]\n",
+        "\n",
+        "fs = AzureBlobFileSystem(account_name=storage_account_name, sas_token=sas_token)\n",
+        "parquet_files = fs.glob(data_path + '/occurrence.parquet/*')\n",
+        "print('Found {} Parquet files in export {}'.format(len(parquet_files), data_path))\n",
+        "for k in range(0,5):\n",
+        "    print('    ' + parquet_files[k])\n",
+        "print('    …')"
+      ],
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Found 901 Parquet files in export gbif/occurrence/2021-04-13\n",
+            "    gbif/occurrence/2021-04-13/occurrence.parquet/000000\n",
+            "    gbif/occurrence/2021-04-13/occurrence.parquet/000001\n",
+            "    gbif/occurrence/2021-04-13/occurrence.parquet/000002\n",
+            "    gbif/occurrence/2021-04-13/occurrence.parquet/000003\n",
+            "    gbif/occurrence/2021-04-13/occurrence.parquet/000004\n",
+            "    …\n"
+          ]
+        }
+      ],
+      "execution_count": 3,
+      "metadata": {
+        "collapsed": true,
+        "jupyter": {
+          "source_hidden": false,
+          "outputs_hidden": false
+        },
+        "nteract": {
+          "transient": {
+            "deleting": false
+          }
+        },
+        "gather": {
+          "logged": 1618319312671
+        }
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Opening one data file\n",
+        "\n",
+        "The whole occurrence dataset has hundreds of millions of records, split across around 100 Parquet files.  We will open just one."
+      ],
+      "metadata": {
+        "nteract": {
+          "transient": {
+            "deleting": false
+          }
+        }
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "print(data_path)\n",
+        "df = dd.read_parquet('az://' + parquet_files[0], storage_options={'account_name':storage_account_name, 'sas_token':sas_token}).compute()\n",
+        "print(df.head())"
+      ],
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "gbif/occurrence/2021-04-13\n",
+            "       gbifid                            datasetkey occurrenceid  \\\n",
+            "0  2305838350  ad43e954-dd79-4986-ae34-9ccdbd8bf568     KM953194   \n",
+            "1  2305838837  ad43e954-dd79-4986-ae34-9ccdbd8bf568     KR568679   \n",
+            "2  2305839278  ad43e954-dd79-4986-ae34-9ccdbd8bf568     KR746879   \n",
+            "3  2305839610  ad43e954-dd79-4986-ae34-9ccdbd8bf568     JN257280   \n",
+            "4  2305840564  ad43e954-dd79-4986-ae34-9ccdbd8bf568     MF731456   \n",
+            "\n",
+            "          kingdom      phylum    class      order         family       genus  \\\n",
+            "0        Animalia  Arthropoda  Insecta    Diptera      Sciaridae        None   \n",
+            "1        Animalia  Arthropoda  Insecta  Hemiptera      Aphididae  Myzocallis   \n",
+            "2        Animalia  Arthropoda  Insecta    Diptera  Cecidomyiidae        None   \n",
+            "3  incertae sedis        None     None       None           None        None   \n",
+            "4        Animalia  Arthropoda  Insecta    Diptera   Chironomidae  Limnophyes   \n",
+            "\n",
+            "  species  ...       identifiedby dateidentified    license rightsholder  \\\n",
+            "0    None  ...               None           None  CC_BY_4_0         None   \n",
+            "1    None  ...               None           None  CC_BY_4_0         None   \n",
+            "2    None  ...  Gergin A. Blagoev           None  CC_BY_4_0         None   \n",
+            "3    None  ...               None           None  CC_BY_4_0         None   \n",
+            "4    None  ...         Kate Perez           None  CC_BY_4_0         None   \n",
+            "\n",
+            "            recordedby typestatus establishmentmeans  \\\n",
+            "0          BIOBus 2012       None               None   \n",
+            "1  Thousand Islands NP       None               None   \n",
+            "2          Paul Hebert       None               None   \n",
+            "3                 None       None               None   \n",
+            "4          BIObus 2013       None               None   \n",
+            "\n",
+            "            lastinterpreted mediatype  \\\n",
+            "0  2021-03-30T12:22:21.593Z        []   \n",
+            "1  2021-03-30T12:22:22.627Z        []   \n",
+            "2  2021-03-30T12:22:54.519Z        []   \n",
+            "3  2021-03-30T12:22:22.628Z        []   \n",
+            "4  2021-03-30T12:22:22.629Z        []   \n",
+            "\n",
+            "                                               issue  \n",
+            "0  [COUNTRY_DERIVED_FROM_COORDINATES, GEODETIC_DA...  \n",
+            "1  [COUNTRY_DERIVED_FROM_COORDINATES, GEODETIC_DA...  \n",
+            "2  [COUNTRY_DERIVED_FROM_COORDINATES, GEODETIC_DA...  \n",
+            "3  [COUNTRY_DERIVED_FROM_COORDINATES, GEODETIC_DA...  \n",
+            "4  [COUNTRY_DERIVED_FROM_COORDINATES, GEODETIC_DA...  \n",
+            "\n",
+            "[5 rows x 50 columns]\n"
+          ]
+        }
+      ],
+      "execution_count": 4,
+      "metadata": {
+        "collapsed": true,
+        "jupyter": {
+          "source_hidden": false,
+          "outputs_hidden": false
+        },
+        "nteract": {
+          "transient": {
+            "deleting": false
+          }
+        },
+        "gather": {
+          "logged": 1618319321710
+        }
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Plot data\n",
+        "\n",
+        "This is a quick plot of latitude and longitude.  We can see the shapes of continents."
+      ],
+      "metadata": {
+        "nteract": {
+          "transient": {
+            "deleting": false
+          }
+        }
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "ax = df.plot.hexbin('decimallongitude', 'decimallatitude', gridsize=(360, 180),\n",
+        "                    vmax=100, cmap='Greens', colorbar=False)\n",
+        "ax.set_xlim(-180, 180)\n",
+        "ax.set_ylim(-90, 90)"
+      ],
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "execution_count": 5,
+          "data": {
+            "text/plain": "(-90.0, 90.0)"
+          },
+          "metadata": {}
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": "<Figure size 432x288 with 1 Axes>",
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYcAAAEGCAYAAACO8lkDAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjEsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+j8jraAAAgAElEQVR4nOy9eZwdRbn//67qPuvsM5nsgUACyL4qm+KG4IqgoqKooILXhSuXr7v3uuvF5Xrdfop6Rb16XRDBBVBR2WU1LCGBQAJJyD6T2ees3V31+6O6+/RZ58xkkknCPPPKKzPndFdXVVc96+d5SmitmaVZmqVZmqVZipKc6Q7M0izN0izN0t5Hs8JhlmZplmZplqpoVjjM0izN0izNUhXNCodZmqVZmqVZqqJZ4TBLszRLszRLVWTPdAemg+bMmaOXLl06092YpVmapVnap2jFihU7tda9tb7bL4TDgUsP4K777kBTguUKxC61GbS1q+3MUmOanedZmqWZo5TdsrHed/uFcKik6WA0s8xqz9DsPO+9pNGz7+dZTLMxh1mapVmqS1FrfJaeXbRfWQ6zWs7kaNalM0uzNEv1aL8SDrM0S7M0fTSrNDy76VnnVpruWlJa62lvc0+R8H/2F9L+z/5Ekx3TvjJ+rfedd7Wn9/jewk+edcIBpnfyhdh/mOss7R+0rzBd9Mz1dZ+ZoxmkZ6VbaboZ+qyAMKS0CueikUWitEKK6ddL9icrKKDJjkkg9gnGN9N7ZjLzuqf7OtNzE9CMWg5CiH8TQqwWQqwSQvxSCJEUQnQLIf4qhFjr/981zc8EZjWHqZDWmow7Vv5ZZB495eEpj2w+13B+Pe2Sccd3Wz+nk/YWE38ims4cn1maJZhB4SCEWAT8K3CS1voowALeDHwM+LvW+hDg7/7fu4VmBcTkSAhB2mqp+jyYR1vaWMLigs9fxtrN6+u2E5NxUlZ6t/VzOkmhUFrNdDeaotn1XE77imDfW2mmYw42kBJC2EAa2Aq8Fvip//1PgXNnqG+Tpn11MSqtcJVT9/vouISQdYOkQgiEEHz38i+yaM78hs/cHW6l3UESuUc18SD4WbmW9sdg++6m/vz2me5CFe1LPGLGdqjWegvwNeAZYBsworW+GZintd7mX7MNmFvrfiHEpUKIfwoh/tnfv3PSz98dSB1Pe/uMlhklgajycyqtwoWc93J1x1VrHhfM6SWdSO2ezu5hCgTedFElk1da4XhFVg+sYntmOzk3Q8Er4GkvFBKe8lDKa9zP/Qx5NlmqJTzb450z1Jv6VFTFfYZHzKRbqQtjJRwELARahBAXNnu/1voHWuuTtNYn9fbO2V3dDElpRdYZbwhrCzbn3qAdaDR9uR0M54cm7I8QAkvYZWMLAptaa6SwDLIk8l3wDAClPTzlhvDE6L3Rn72dmumnUh6OV5xwTj3llRh8xRyE1kGkPMXWTD93b7uHvJtHCCOQx5wRI6SDO3X5vZW/R8cRfc7umovdSZXPb9SfyusCSlp7n4JiCVm2l/YUTWUfzqRtfyawXmvdr7V2gOuA04AdQogFAP7/fburA1Wm+wSMP+fl8PtV8xpLWkghp6xpRrX16aLtuW1Tuk8IEY4lbsUbjklpHTIxMC6jWm6jvV1QNKN9a7Rh+g0YVYjhn0CJgJJg7kn0MFrMsjmzCa01jlck44wDGktYWMIK2/d/oayrIvqrCNue6lqcaUtkUmiiYLzT1Od6rr3pIFvGkHLqPGJP0kxCWZ8BThFCpIEc8FLgn0AGeAdwpf//73dXBypfUKMXJoSgJ1mzsm0VKa1qumomospCZ7tS+EwgmJuax9zUvObvqdNfgQBREXuI9EsKgaJaIAgh0FpXIcT2ZfeHJW0sWX/bBHNliwZbq2L4QgqOn3c0J8w7hlWDK+nL7WBuai4xK2asNvy59NdD2fztI1M5lbVcJkQnuHf6XcQutoxNa5szSVOZnxkTDlrr+4QQ1wIPAi7wEPADoBW4RgjxLowAOX+m+jhVGnNG6Ig3h8CNMs9AOyz7vsamCl03kXubehYadG0hEH1OZbvB3/WeJYWFrNON6D37slDYnRSdl6O6jwFM/OqJwcc4qvv4qnUxEaPdW6up7q39qiQhBLbYfwTDVGlGk+C01p8GPl3xcQFjRexxmq7FWwvuWY887WEhETXcMI0SmjSaoioQl4lJCYiCypOQyep7NGhhxu9pDwFYvvbraRcLe58whWeapmMNaa2RSI7sOg4Z8fxGYznPlnexK/O5rwijvZX2DTzhNFHgFtFaUXDzta+pYMZT8Y9bjVwKVddaNPINVFkNEddOXMbDzzLOOHoCSGrlPduGtvOmz73fjwIoPOWGfZKUtNXJjGeW6q8ZrfWE7wdMbgX4a0PUTnDbVxAvAe1KPGBvjVHt7/SsEg6jzrD/m8CS1S6c6aKiLjQdzJooaKj9YG9AykfAmJiGDO+PW3HwP6v7LARSWOZ5Ano75vCWM88Nv8W3Gio1UyEEChWBVrpNjW2WyskE+Sded4G1ECTgVQqVPe1/n6VnJz2rhENMxsP6P7WCTVHtJsrclVbk3FzTDN/CmhIqJ1qpMvj/4ace47aH7wmvCYK+lX2JybiPfGle6FnS4pxTzwR81Iy0/PGXQwO9CMZeacUzg5v5xd+un9TYmqGZQjJNayHGBhqyRoeB5YZtVCoMJlRUghL7SLJ6NN1Im5lEmO2KxdHoPTxbrZF9Bcq6xyltt1RtqkaTpbWm6BkrwNUTuwMCitWBfkY3rKfcMuhqaCEEGGi/YmUynuAvD9yBUoH1ICYFl603vnDTVUAgpZDIKqtKIyNwQSy4/q6/4HpuXUa0r22+8D3U+Nltz6xo3/GKZWsigAQLKRqjnyb5vKmOaVfnYk9j+yeChk95HiJrfjJzurcoPs32Q+wNCVu7SieedIL+x313NXVt2cRUIHeCAJZZVIqh/ChKFOlJ9iKRVaidqCbX1DN9bLpAUPQKCASWtJHCtF1UBSQWtg+VDKCgCoUlLByvSMyKNzkru4eCfias5MTXTjEg2Oy8ThdFnzcZuO2U0GI+RRMJg9/zbhaBJGEnq66NPktpRdErBl+Chr6BAeb2dJfeiyh/TvT505ILUGMsE96zh9+rqxwssXuBFFOZhz1JlXMeIh39/1N2ywqt9Um17t0vLIdAvk0k6GrVq/G0V/WZqxzG3XH+455vkbbaw8AgwiB3XM/BU55/vxvGAaLaRC3ytIurXDQ6xMu7fjq9o1ziMkFOZSioHBplBEjEVTRcHGK4ODSFGZo+EkKQsJJ1x1hGU9Q7FGqPMRAod+NUujEajdPVDqsGH57882pAkwGSdpqEnax7rdIKT3tkC1meGHicPz19Iw/uvJ+Vgyt445few//e93+MF8bNeGq4Y3ZHYttkS1/vyfdqy9huf56g9lzvLVQ5582ubdhPhEOUGqE4PL/Mg6dcgiQ1WWMKYjJOi93K11/4UVpiKRyvSNEroLRnykyg2ZbdzMax9UgsBBKFwtNuWAunqApV7RZVkaxfqjqQ3lLYCAQfv+tKhBC02R0kZAohJDFZbiXMSc6lPdZBWRYuNUoN1CrcFnFfTRdNtLgcXZxSu7XeyUxSvXHGZJzDO49uup1aDKTWZ1prXNdDKeNqvHfb3Vz4u4+wZmg1Vz/2I750w3/z0vdcxDs/9GkeWbGeJS0HkrRTXPGlr3HgG09rfmCztE/RdLqlmhFm+wVGMaocNBq0JSxTmkAXsYlV+dyBUNu1hIWUhknZMoZGIZAgYMQZJu/mWdR6AMLP/hJaIHz45ynvO5d7/r/ryToZQJOOtZr4gZUKGb4Qosyt9cmTLws/D83/GhncgVBxtIONHbqpogsn52XIOlk6E11+3zWOKvi/g9S7nr7fKAcjoJgoCbd6Lo16rqd1I2tY1n4YjnJ8JNbeRWYdOSE0uFmaSEAopVAozvrIhWzduZ3XXXIW195wO31PbUWvyfHF913BqvQaDly8lBcsfB7tLW10Jbr48ce/yllXvIPffvqqsH+udhDUBl80HFvFu6r1jgJXl4dXFwTxbMrH2FM0nbkbE7WzXwiHgJpZiO4EafHXrvszx/QcwvLOpVjSxlFFbBHD0wpQ2Nh0xruRWKTsVDkj9xn19sF+bGkjhcDVLjk3S8pO85eH72RgbJi3nnEOAXIleEHdyfIKkkWvwLgzVrdkhy2sspcbZdYJK+UbuiUN3JKxaTd/J4RU1snErry3csELIZifXhQiqGaS6o1RCIHN9PftYz+8kofXrebRpx4nU8ixfmQ7mS3D/OLD38ASNotaF9Gd6GJj22YO6FhIyk4x7owxp72LX/37tzlsycFh/4wSMD1WWE0B4T+jHnnaQ9IcfHdSffGt5n2l7Pu+SvuFcNC6+ujJSibkKc8gP6jtSgro+N7D/d+CoI0fiI60K4SgO9lTdl9041x5yUfJFwsk4wlsBAWVR2nFMQcexq2r7626vhbFZLxsUzmeU8Yso99VamhSSFJ2eZa21hoq/I+T0eyCa6cShBWUrCRNgMrSDWsUtditPmpLM+6O0Rpra/qZTfdtF8e0K0yvcn0qbXIatg32ceejDwCw6JglvGHZKzjtdcdz1klngNBGUbFdlrYfEDJeY70Ijlt+pAE3+G7HRvPbiCYbR6hHAdCiUXNTDZLvrWi43Sm4yhSqBms2Oqe7EjDfL4QDEG6Iygkr+djNS7OlXXLd1KgztKzjwLK/LWmF0NJAC5NIE8jWVMFKtda89czzzB/CXBu3TH7FvM4eXn/qWbX7GdHMgnhIV6I7/F5Kiac8LO1X5xSR64O2gqFWrIHAYjBTUXp2syiroD/RMdbqf/D8mgEwESlIqH2tUltNMGWD7NJ2625xUYQxqgiSzPzp53dojQzyP6bp8WWlzUUJPXLnyvsYGTfHsL7g2JM45ozjeNlBz6f9OUZQFlQB24ohsVA4xGQCpTxsGUcg2DS+iYUtC4nJmAleK99KFvUZw6QUhCZcGhqNVhrhPzNwzU5H2wEJIbB2g9XWiCY7T7vbpdZM2+GejKbMTKJf+4VdJoSJETQq8iaFVRbADRhZZaXRyuSjgHJeFqVKqKSCm6eoCjzTt6WsnfAZuvQME7Q2DCCKRonW+t+0YytK1cdlW8IKS2dH3VE156PGd5a0pqVUcD3ESXTuKgPildqhlBYxK1EWX6nUBKNY/+7knCn3u+x9UPG+K6rFlv2uNaBxcQwaLVgz06Cwusql6BnAQjAnz2zfyh/u/jt/XXEni+fO42Nv+xeufMUVtCVaQms1aSdxlIMlbVJWio19m3GUgy3M8axPDD/BmDMWtptxx8vWej2aCKTQCJFTC+MvAkUgMr+BxVi5NvZ2tE9Aza6/AF04k7GWsrkUNRB4TYJS9gvhUIsC6R2dJylMQDmcHB+eWstEjTJhKSStsXZsy2hhRZVn1Blh/djTXHfnn/nhjb8sfy7muY4uhu0o7aEiAiTYPMFLe/UnLqbgFCe9qCqZ3XQuyuiiqregKj8P562WAKnzeT1/djN1iGq1Vesz47bxqp4vhSwFVHUp0Kp8wR2TCTT+KX+ohlp4s5R1s1z71HUoFOOFHKPZcX7852u46g8/B+Cz772M0w8/OexXFIFXUHk2jD0FaH7/j5u5+qbfhPN05pIz6U50gzDKQGeiO1zz9WiqayYqFCpjX0LIMpdWsI6Cd/BspSoFaDe6xqJCd6rP2W/cSrUoCCYbgaCwsPHwuGvznfzX367l+nd8s2bAU2kPUXE+QQg9RWLJGF2JbnqT8zjo3IPRKgi+mR+FCpkMUFWuI0AqRZniih/cSMxqDlUSvc/RReIiMem5mayvt95zFOYIy5is/q4yuawu6qXGpjEamG0SA2vAehtRpYvO5JVYE2pMrnLQQMx/V8Ha2TS+gZ5Eb824x1TQIx2JDs5f9npyTpbfPXI777/qM3jbx7GkWXNDzpDJoPcTJKWWFH20WWusjXR7C1pr3n/uO/CUx47cNtribbTGOiioHIkaJ6BNJ8plqszG8q33ZzOCaaL3sLvdURpNzssSE/EJUYD7tXCI+b5YAE0pK/DUhafy3fMON+ZfjRclI6duRX3QEBzfOMqc5FzD9HUMaRttKfBLC220sbiMl5hwhQtDoRC6hHBqVjBAedArJuLTuvHrURSWGiWJFcZiKhd2wNDQJcZQT0BUkkabshEqhmJibTNot5awqYrN1LgXQQj7DT5T2kNisaR1ac34lNYKRxWNi6zWGGpkBAd1ulauX8s7/vtDqLEixcFRUHDpBa/jkjPfxvyO+eRVlgRJtNbkVZahwiBzU/NDUAUCYsKsvUIuTxsdAMRE7b7sLpps8Dp4P3u7G6lZmm5m7moHz1Mk7YkrEEyFpJCkrBTNBNBmVDgIITqB/wGOwnhG3wk8AfwaWApsAN6otZ5SWnDUbRP1hyesJEs65ze8rxaDUb710RprC62KICAthMBTLhKLgpcnZadBiDCrNRZhPEF7U6U1Q6v5/bq7eN+xF9KRaJuSJjfZ59fbANE5VqiyHIowp2MKYw0tNWGqOk0qYDnZ52nCEiX4Na4sYZmqqOaMuzCfpew5QiKFheu5CF+4RMn1s+fjMo7wUUT9I4O89YuXYWGx6ZlniMq9eDxGb1c33alOPGWsz4Kbp6ALpOxUeT6BNtV/c06WOam5pKwUKwceZH5qPgtalphLtBFwU0UtTUR7ksFPFdW0u9oJyNUuNnYZz6jXdjNKkS1iCDm9rreyeAO6pMhOQDMdc/gm8Get9XOAY4HHgY8Bf9daHwL83f972qgZhE4jZquESYYLrom6nmRk0j3lkXUz/nnDqlrYBK6WSKbzh7//pbIKqFHKOuPkXXOG9YKWRbx4ycllrpPJ0ERjnCrJyLxApHBcndIU9Sg6LiN4Gy9Tx3MmrEQaQEUbPXO0OMqTQ0+G8xO8z3pxDDBnXQgEaFH1jODsZ4XGUUUy+Syf/ck3+MejK7jj0fupNIhuuOVONm7dZrLjrZgPXbZJiCQtdhsZJ8P6kadR2qOoiqHWOpDrJ+NmWD+6CYFl3GPhXEyNCRqlpnZp9l0JIG/Pbp1Slv7eZmlodOhKhuaDvBORcUHXF+ZjxdE9VsBwxoSDEKIdOAP4EYDWuqi1HgZeC/zUv+ynwLm1W6hPlRVOGzHCgKlUXecjUwIGHrgDxoqjFFU+vGfVzrUMZId9WKupwWSLGFprMrkMdz5yP9t29vO7u2/msWfW4Skv7Fv0WVprlHIZz2XKUExBn2wZM3WZtKYr0c3J84+nLd78iXOlR5Ujc2qOfYokRKmUdC30US20SpOdrnoXXqSelRDUReRUurLCuY30I+h3wkowWBgsgzoHAq5m2z5ztqQVljsP2g2EvCVsJJLhwhCOm+c3t/2x7jA3bNrK2o3PoJW531MuUpp4y2hxFCksHtyykns3PMyO7DbyXo4t49vYmtnCaGGEecl5VYUZw1yDBnNT+TsElnLjdzWRkhGs9eicCyHCzyZLzQiIidZxs4JNV/zUbS8CC58IvFFJBa907kv4HnTjZ4o6AJpmaLL3zaTlcDDQD/xYCPGQEOJ/hBAtwDyt9TYA//+5zTRW9iJ9P35wolb0+0oKLQmfwdR7sa7rsjOzk9WDK4kHfl0Bg/kR7ty8AiBk+ra0saRFym7hI9//EkXX4Yrvfp7PXPNNf5MYS0JSbt5d+Z6P0ZJKhYwpupDjVoLWeFsZumrt5vWlstkTvPia49el7xqNfaJ2m/ku2DyOckJG0SxVwnejDA2M4Azw9GXCXpfngkghqwVzhBJWglPmn2pABxVwxHrMImB4wT9LWr5w8Q/q8a8dKPTj4tGabq07zmULl2L5lpZC4WqX0cIIjiqyemAlMWlzSNthfPDXX2LV4Coe2fYYQ/lBNme2o1CcPP9kv9pv9baezHwHeyjICdoVKrPWBMxLLZiWdhvR7rCKK0lgIKv1yuc3FKr+2sx5mTKhoFTpcKd6Q2iNtZcn+0bWejN9nozVN2Mlu4UQJwH3Aqdrre8TQnwTGAUu01p3Rq4b0lp31bj/UuBSgCUHLDnxiacfL31XEfSayBcYUDS4VAaD1TA0PsIp738tj/3kb1jSrvLjQSTJKwi8aVN7ZiDXB0LQEe8i72bp9JPbon1slqJjOfUD53Ljf/6ErraOSbUTbh5tavlIKUs+92mmyjHm3CxPDz3Fkb3NF6xrpt3oZ1rruuMpeDksEWtoulc9K7IWom6mqjWgy+NVAWOUSMbdUVpj7QyMDLHkTaeUtd+ebmU0O863PvBZ3nr2a0nYidBF98PV3+cVS1/OAa0HobUpl37TultZP7YdOSoZGR/n0he8nt6OHqSw+J/VV/POIy7ClvaE677e+gvGO+F+mWD9TmV97852pvOZu9KnwB1VmVjqqCJFVcAStolZNtNPbdxbk1nPUdpbS3ZvBjZrre/z/74WOAHYIYRYAOD/31frZq31D7TWJ2mtT+rtnVN7kVeI34lMxOBYxuD3aD5EV1sHq67+a3iecqUJDlRZAn5HSdotrBlazZbxjXTEjZzLFfJV7Wg98RnD0fbv+uZv6WrtaHh9o3Z2jgzR8ZqjeOHlb9x9lVArpjtlp3l63Q4u+9anpqHpeqZ3eYmU6HVxmZy0EAxKsoftU76pA03P1X5ymy6/TqEYKgz4FYFLmrQUEtuyeOOZr+R9r38L8XiMe/vuoT/bZ/IqtMe5S8/j+f/2dgpeAVc5ZNwxxraMs/H+9Vxw6lk88/RTHPGOM7n/sZUIBO8+8p2l80B2wQ0T1fhrKZD1YmPNtj/dtDuU3Gas8alQrb0mhCAm46StlknBtoOku91BM3rYjxDiTuDdWusnhBCfAQIn+oDW+kohxMeAbq31Rxq1U+uwn0qtKbAKGkn8qA862BxBTkKAH5+KNYKAvJvDElZ4nOeHvvd5zjrpDF723DNK80HtOj+1IJEABS+Po4q0xtob9qERbd65DVe5LJ27ZMptNCJPV1ft1FqzY6if+d0lj+FkNbFm57/WtZO5N+ivf0PVfUorXFUEJForbBkzmqGQWNIKrckAASWEYEv/dt+NadaGlAKZ0OQKeea3z6eoCrTE2tAaik6RQ9/+Ip755T24OGhl3D39wwP0dvaQd/KsG1jLAZ0H0pXuqm8NRC2byF6oNw/Rdeh4xapcne89+gPefcTFDBT6mZ9eWPO+yc5z9P7ovc2sDU97CCIxr2mAmDbkFc3u/yb6brR/U+qk3l6PXjudLrlGlsNMC4fjMFDWOPA0cDHGmrkGOAB4Bjhfaz3YqJ1mToLLOuOmGF2NDV6LqqwOrcqL3U2BOYHRuAQwODpKwcmzaM6CoENlFG13zBlFaY+2WEeZvzEIzNrCbtq0rEpM88tE1CsiV7m4NRpPuWTc8dAKmuh5tRZzzs2i0aT9AoFTYSTN0q4Kh3rtAKELK+tkGHWGcTyHtnh7mJ0cxD00mld89O3ceOVP2Jnfwfz0otBNFAgORzugtY9ysnnlRy/i5q/+H/c8/iCnHn6Cn+Fd7o4IaihJUR4UD07r0xi3g1IG0ip8C8cSVghxrceQg9895YGgTMjvyPbRFe/gBVecz5GnH8/Vb/osYBIJlfaIRw6Emsw859wclpBlgfWm9lgFUw0SYANh6GpnUhr5dFGzc1BZOLReW8FamS5qJBxmNM9Ba/0wUKtjL53uZ8WthHkBNC4nEFAlQ6xknlNhYkor8l4OiaCnozPchJ/68de5/PXvpKejCzTkVY6kTPnPNcFRA09UaESIvS+Dierm+uNpc9CRxCCrTHxk4kUZHa8UlkFkNbHw62k5cSuB4zlh+7uTmsGXRykI8Aeb1VOun9NQ2x1gYZGOteAqhyF3kDFnlJSdJi4TZYH0i17+BtCahP9u71+/inX9GzjvxBcjRYztmW30ZbdzcPsyuhJz+MB5F6O05pTDjw/fU3DgVEASifSt0cBtWuVq0KZkhyVMmXmzlqMCxgvXg/nbuFSDIH9Q6TVKc9O9aK24/Nx3Y3eXErYsYYdlYkqPb84q1GjiViwEWUxGQ668tpKBRte4p1w0TNlPH/TVtFtt5UfXTrPU7PV7MvYy03kOe4yC6pSBthyFHFbCWSvRNLuaR1DC7Qe5AJFrNGxxt/O9G37OeCbDjuw2PM+j4OXDfqxav5ant27G0x6OcgyyKBiH0jhesQxCOhF6QVf9Un8cfmfLNoNAGI1fAw2epbRCKUXezVL0imXXWcIiaSerkBmVMZjpgtlOlqJrwOQxVPu1g7yGYAzpWAstsRZf6Cv+uOo2do4PheM4/0WvBiFoT3SAhnntXWzs38L9jz3Cus0bSFtpPOXhKOMiec1pL8UcF1uk6BXLYNCu5+B5fh6CqH5X0WzvoPyIq50wAaoS4qopR8mE7VGO9HI9JxyzQPLmF7+GNxz3srAdIQRxK171zqr2mP975RxKTCZ9ANsO13rlzwRrI4CVB30KBIHSymQdRWDVZft+grVWNa4a9wX9U9pDqfrouJrtT7B3o3DpyvE3O4Zmab8SDhO5yIKJdVRJY607kWKC7ydJZkNabN85gNR2uDiFELz0Badxx5r7GM2OsWl8IzEZI+tmjCDRGsdx+c1tf/HPrTYlG1Y+9TgPP/UYj29aR85PjtNaMzg6TCafLcsDiC4ky4fZlqyGBlp/pVYUMMwyrHVjRAcYS6ig8lXfB3GdSi0snHdRivlM5T0E90z23kDzDrRRWaOirfIDy1G4qqdcElaKpJVEYvHUzi082bcRLTQ6qLeFgSwOjg3TlkzzL2eez2BmmF/f/ke6Et0c0nkoHfGOcFY97VJQORxVwNMuMRkPM7cLylcgVLmAjbqFgvEkrSRpuzX8O/q/Qd/JsvdgRZhrMIdmFM0xIFHxU48CARG5EY2um4BXxjxr9K+WUhZ8Fq16HHoCGuh9oRCK/EykKFaunakUj6zbdsV4op/Vo3pQ12bgrzMac5guaibmAPi+R5dNmfUc1HZI+HkjpNOkrYbAf1vHLL7+rr/wpwdu5Tsf/KzvGrLKzPYAmqZRxIQ5B2JgbJB0OoX0F17ey/KOL3yYe1c/jOO57LjuQSxpNMLHNqzlw9//Atd94SqU1iRksnSUaSXTmIJFFLQRNWvcbkAAACAASURBVJ+nDOmrY95Pde6r+jvNwbsoqaCukoiTc/O0xNNh/GEwvxNPu3Qne03egg9bVEqxdnQNy9sP48GnH+Gj37+S73zi3yl6BboS3fQk5zJeHCdlpxBAW7wdrU29HTP3ELeSITMNXCe13F41mWQdl0clo68XBG6GOTZDZdquLxyiayCEAAcxm4oYS1ASpBacvCG8WSsKKoenPVJWuunjU2u1PZU1OhFv2B33B6fxgaiCzioUrbH2vRLKOm2kdQ0NpAYJIbCFzUGtRjDsDv+dp6v9pVEz+JzTzmTZ/CX85KbfhlVHo/0WCIYKA1yz9jehrnbTvbfx5q+/h8cHnyAm42it+fWnv8vGa/5B328fxNMl7eTwpcu54Us/IS6TJK0UOS9L0S3BK6PPmSyV3GOiDC46VQ3dknbN4FqtDT5V8ipKRE+1rUpNy6wlUxTw8b6nuez3XyTn5BgtjGBLG6UVWWec0eIwI8UhM/8C+oZ2cuy7X87Bi5bwvY9/hsM6juSQliPpjM0hLhLcsfUf3LrlFhNM9bX5vJcjLhNh5VtPu6HbEahilFD7/dayFBtp2rXmqllrutE19dZRQGHZEh/FUznvgdYftdpq+v51aRwahasd4iJBq91eFreZyHVZCUCo9bxmKIDH573chLwqSkHfCn5lhskKlqyXCROCw/mqMe+VtF9YDieceIK+7d5bGC4MknUzLG1bNmN9qQVFM8IhyKEQaKXJFLK0p9t4eOcKDul8Dq12a2jibu7bytu+cjk3/OePKKoibVY7o9kMxBRSCDLuGF2JOdjSoFqiZmy4sZWparoz10fSShKTCSxhGQ2tScRWtP+NrI5amuek5gzjFqkL39sFS6KWoJ5KW8ZNp0wtJV97y7oGAScQbB3bxm/u/RO/eOQvXHL2azl9ydEM54dZ2r6UzkQPSZniG498iwsOewN/e+ROfnvLrZx3+ou5c+X99HR1c+Nj93LRa1/Ji5c9l9ZYC/PTi2iLtZfNe3nfdanmVGTuajGPRhp/mcsFFSKYKhFL0WsDauguajDPlf0JcjqiaCLj/i2GTDxaWj+4P8g/CU/qo7SWFApXOXja4+GdKzi25/jw6NxKy6no5bFkrCoxrXIsUEp0bSaAXLX2AmGlS1n1zVD4/EgMqFkKhGTwvMr3stdCWaeLTjjxBH3nfbeDhpyXozVWv0TBTFDUDRP1wY4Wh5HCYme+j/mpBSTsVPjy7l/zEH2ZPv65ehVL5y8iJpM8vWUjf7jnbzzv7GOYM7+bD5/4L2zJrmdp6yF42iFlp8m4GdrjHVy/8m/knCJvPP5laK35xI3f5o5b7uI3n/wWB8xZgkaTccZojbVPWLkz2HCI2i6HekyjWTeERodIskabsxGDm4ygC9qajBZW2mSAr4Gb2keWz6gU44VxntyxgUJsjM5UK+0+9HhrZjNHdB7DEZe8lN5FC3EHszz5zAYuOed8HO3y9/vuZvPOPtqX9HDkcYdy/qnP52VLz6A70UPabql6N5WMSQXnowtZO6+kEaP2Y0iOVwxzcKLzWTZfNbTriYROI+EQZXqV7i5Pe4w7oySkgcSm7JLbLmpZaHRVaZXKo19HCyO0xdsAEcJ9y+ZPKwSgIv2yasDWwzZpTpExwouqM2MKXj5EsjVD0+VmjbbXjHDYL85zEIIwgNYq97xg+PZ1P+aFx57CMcsODz8regXiViJ8sbU0DQN/NOWeb916O4/2beFVy06mxU5z0qHHsH54Pdeu/BMHdR7EvFg3Jx9+HM9ZuhzZ5TK3Zy7/7L8fS8LStuUIbQ7HCc6weOGy57Jq2zosYVPw8rzmmNNosz2wNF+570ecvORgjp1zrG+am6MroyUXAgoWUVCOOxAQta6pRVFNLrg2upk9ZU5ne3TgEZa1L6ctPrWEvmYFRPSayhLjDe+LaF6VuHmNySuwLMkJBxxF3s0y6ozQarcx7o4RtxIIKfjGJZ8jK3Nkx8Z5YsMGrr7pGv7ljefz5te8nJHiKMQFhy06jAPb55H0D+zJuTkybpbfrvk7r3/Oi+lKdOMoJ5ynAOgQcC2JNIw+WoBPR0qSU17mxdMuFlZYEyposxlB0KwrZqLv6gEjUlY6PN636BYo6kIYVNf4wAit0UpR8+Q5YcYZoMNqrd3g+QAyAgevtZ6EaWASJEBUz1GsyVhH2XOnkZptb7+IOcw0HX/IUYxkxqp8o+VQwfJFcuO9t/DM9m24yqHN7qAn0c1Nt99C3+hOvn/TL/jtQ39FCY858zt46JnHee6RR7NoXi/nPf9shraNcett9xJzE/Qkeil6BWIyzo6hnfzsT9dz20P30JVq5/kHH4/AwPiOnncoF5z2Wtpb2ljSPg+hJbawS1pcBNWQd/O4novnlaCTZUHNCBwxHF/Uxxv8rgm1Qq012wZ28Jd/3lGGGjHzpGix0mEZ6jJ4Y4Qm8nVPJp5QGRRtdF30J9xYfpzLUx6O52Bj4ymXO1fez1ObN4cBz1a7jXnJBfxzx8O8/OQX8Prnnc0bX/RqLjrnfNJz0jy+dgPnnnEmczt72LF9J2tWP0nf0E4ABvL95L0sloC8lyHvGp+zq4plFW6FEBC4DARA7bUX9a2X3p+pviqx6vreo1p6ZcxhUnNeA/lTi1G5noFr2zJmXKFBfED710eRWZqwemzonoww8fCd+Xw6hMhSvmbLxivK13qwjsHcHz1LPjq2YK5C6wIRIg6jz5RNnjFda77rXbc7aFY4TAM9/+jn8oJjnlf2wgMTPfoTpUw+y49u+Q15r8iO7BBH9xzDnLE2emO9/P6vt/G531/FuDNOMpbAG3RCFBNCMz5W4B8PPUi3nsvy9kMMjt2KY1sWP7jhl/zgxl+Wmem2jNESb+Pg9uW0xdo495CXcPzc48u0MFv68FpMBnRRFfzfzbkUUQZDYA1ENmWtxW5QVyWhg9D88IZflgkX4+uGha2LwmM4PRXkeZQLiKgQ8yo2aD1G04iC85UnG+ATQpjzxP35yHs5LGnTt3OIgbFh/nT/38N5Tcda6UnO4amRDeS9Apa0SdpJLGFz0hnHkE6n6Ih3sWXTTn735zv41e0385v7/8bGkU3cteZ+8m6emIzzusNewtz0PBQq9J1HGX2UbMsOIaHBOKPnp4crUlRDVsMxVqzb6FquvGYiKmNwTfAxDeFRuwFZlk0qli6N1xfOQkpsy65ZbTdaNVVogdagohBZUWorsCyCOarVz2CtqRL3L1NigvVMRHGqp4TUE7TNCINatDsExH4Rc2gWyrq30ZW3XM2xC5fzWOZJLjjsHOan51BQeVZtX8Xb/uMj3P7dXyCxaIt1YEsrdM1ISos+qu3VgpUG3wXBPUtYbM9uoTc53yBB0MT8syIsabRfpQ1s0rZiSCFZO/I4B7QeZPy/WqPwqsx4jSbv5khYSTzlMTAyTFt7iqSVQitN0SugRalchkLRPzxAd3tn+Cy0Nhqw0qwdXcOBbUtJWrWrUwbuOFnnqNfppqjVEN2ISpskv3SslZsfuIM/PXAb/3nph01RPb/OkvbLnCRkMmQ+qzY+zkVfu4IvXH4ZaLjm5j/zmztu59CTDyGVTnHe8Sfzk//5HXd94zrG9RALW5agAVvYYQmFnJcjaSWrfO4h76oMxOsS062Cvdbw+092XhpdE1CtQHet+a0M/Ibj8ufPVQ4xq3QMsKtcBCYnpUYH/GsMJDhuJcI2KwEkQfwomIvKwLklrLB2Frq6dpjG5FEl/GdEYbmlcZh1HoynVnxnovmcrjW/3wek91XhMJ7N0JouHdgT+LI97TGYH+CRgYeYm5rPvNQ8xt1RFrccSNJKliE0avlBawWLc24GW8SJyVjoO1daMVwcpDs+J1yk2UIeyzabJfCpbxx7moXpxSAIobRBfwMh5SiH1UOPkrbTxKXN+R/7IH/43I/p7epCCMk/1t/Fuz737/ziK1/huJ4TAcFVf/g5SsMHX3cxYOI0toyR93KhEAnGUIuRNLuZpkK1ntnoWVHNWGmFowvERJxNmY10JbqJyziOo1h8wSmc/a4zueCI0xkacfjwD79Fbr05BTcZj+Moj0988CLeefrb6Ih3UFAFtJJ84h//zXde8im0Vsaq05otmS3Y0mZp28HlcRwfvlt5kp1x2Xm+JbHr9Xkqmf5E1zYMTvtKTlQ4ucr1z7eQYTC6khE3EjBBv7TWONohXlFbaTLvVAjhQ1A9LGw/RiNDEEVdd1y0HxFFLSbiTYEvpgttV49mhcNeRsELv/jLH+LSV1/AqUeeGH7+xPBqWmPt3LfjPs4+4OU81PcY64Y3cM6yFxvYpBJIy6BS4jKBp92wwFpAtZhaJT7bCAcvUF4IkBzf+/3PyDgZLjv3IhL+IeeucgFNxh0nLhMkrCQD+Z38cf0N9CR7OHPxS9kwtp7h4iBxGeOQjsOJiySWbeIaX7zny1zz41v41ic+ypAe4oiuw1nQsghb2BQKDt2tXSbwGDHFBSJkBlUbpnIj6sm7hhq+nxpz2SwjCdwbeS/nJ3ZpZHDGsFYMjA2QEeM89ORqvn/jLzlo6UJ+/qubAM1H3vVOMr0enshx2fEXc0DrgTjKwdUOaJt0LBmuHVe7YdmUuJUocxVFffuBhhv6+bWoypAOx6DNOw7ce5OxCiZrPVR+Ho0ZSCnL4wp1YLp110VpUUc7UBPiW68/wedRt2iQrGoKHZYEbD3hECWB8IWdhaPrC4fKflWe/RDkfjSbwDcR7a3nOTxrKdDav/beT3L4gYeUfdeTmkNXopvTFzwfVzmcPP94zjzgBSStNK52+NBVX2DVuidJyKQpyocdmtm1auwHTCPqd857Od/fbCMR5NwsBc+Ut3jnK97Euaed5W8K/6hVv2hCghSv+ug7cZVDzs3w4kVncFjXcr79p6t5yyc/wl0PrmBueh7pWJpUPElMxCi4OX541e/I5wqkrR7+8uAqFqQX+4xM0tnSSZDsJUTp9L5aSTqVGzBEpVAdvJ5uajqm4TOmlJ0KXRCBNQiCVDpB3suhuwqcd9aLefUZZ/DrL3+d277zS8ZbNScvPApbJih6DnkvR0zGsWWMuG2htEfeyzFcGMTyXYt5L4enXLJuxlS6DTDtvnsk62ZwVBFXO6aUgz8EVztlSWQBBe6Q0nAmZnrNXFfWptYUvFxVOwJBURVCgVil2ESKCzbqo6IEoojGTGr1vUww+LGGyrgKQF9uO5szz+CoIhpN0QcFBOQpj8F8f8M1ctOGP7N5fLPZs5GxucoNS/pUUuUZ1cG+nYimIwaxX0BZ9zUSGM2vq629yry3/TOH12/dxNf+7384+8QXccmrLggRPJe+5gJSiTRCCHJuhrhMBF5kwxBUKR7gKZfAIohSTMZLFWoRYVG2olfAsi2WzF3oV+Q0mouFqeKpcbl39UNc+IV/o+DlOGL5co496Qi65/fyr2+8kLk9nXTEu4xmheTS//oE3/7gp/nqpR+jP9vPIXMXc/ZhpxO348RFwo95GC94cPJZWda1KM1X1K1QuQF310FFzZruwbspg4MKAVpT9Ipc/qv/4utv+BArBh/gOV2HsCO7nYfXPY4asHnZES+i2Flgfnoh7+99KwLJcb3H4JBhqDDA3FQiwoAh6efCCCF8rLwpwR234mVzF/i2bWEjhcQLwAbaw1VOzaQyU2F297CEqBAxhfBi4ecBQk0gDPzbf9caRd4rMFQYZGF6cUVCmTIoKymrnlHv2ROROezLwxblWrkQgjmpXsaLBpE47o7SYrchBDw2tIpDO56DEJC2W8NsdqiGrx/XezQpO8nOfB+2tNk8vomjeo4N575Wf4PPPe2FsOvJ5Efsivtp1nKYAQpQIlqXNIJgg4wWR9FAqi3GoYsOplAsGvYpBK52OGTJMhbPnY/J1o2VLZSR4lC5WVzH3A3x7igTRxBxY+6qIrc/cjcPr32M3915M+s2b0Cjwro9BZUjEYtzwz1/Z/XTTyGFRTph055u5bzTzubkQ07AFjGyXoarbvg5hy0+mELR5ZyTz+K8019BXCZ45eFnILRJDEpYgdvKKVWvjKCHorDW6HngteZzMhum8qeS8m6OTHG87LNoIUNPmWqbOS/LUH4ARxW578kVXH/fjfTndjDujNKX3U7eyxrNPZFlw+h6RgtDKE/y4JYnOWHpUaRkinnpBXQkOnGVy8LWecxr6eKgjiWMFcewRIyhwgCjxWG/vLnRMtGluEKQ+a50RVl5DcIPikthYfn+8fDdK4WnShVWwzLdopzZ1nWjVaDIGjGhcKZ9pFQwhuDsh+g1QRa/ga8KBgsDxGWsHNrsx3ShPhw2sM6NRr+zrmUZ7RvAt6/7KeO5sTI0nPAVqK5kD7YVIy4T/lKVdCW6UFoxUhzh+sduMdVzfQEcpRU7VvLLv91A/4CJLz2ycyVFlTfH9NaoixVdm9H/J2sh74oFMSsc9gBFX1DUf1mtaZq6+8+MbCMWE3z6ost577kXGly1vzCUViRkAoEkYSVM4T7fahgtjBBg3I0mJn3GUcLEV/ZH+G4j4VsRwhLc/sh9FLwCj65/nLtXPchIboR7HlvB3Y+t4MiDl3HEwYdw+IHL+fD572FuSxdnH3o6nvboSsyh4OXpz/azvm8j573gbLpaO0jaaeanFhC3EiTtZFkmuMQKfbtQ0pqCTR/t665aCPUgipUkhGTMGa2bZxG4FsazY6za/JgRbFJx4723sj27nbyXJ+tmGCuOkHNzPP+Io7h/7UNs2dJPe7yDbSMZnrfkubz1la/xg5MxXFUk44yxM9/PbSvvwXU9WmNt5LwMo8UR+nJ9huFozbg7hqddEzNSAcP03YCmo0YBkSVUmyVt4lbCwJ5FjKIqUFRFhvIDFLx8iUlHcyHq5AGUzWeN+Ql+j67Z4NqgqKSmdCxvEBuJxktMDSUTewhOOtw4uiWshhuMqRaFbfnCY9wZrWa0kRwGA7M2mcur1q8hU8iGI6icBwuLlN1CTNrkvSzz0guwpY2nPO7bvBJXeQgtypUJz2N7bgerB55k5TOrjaLlFXl641aUUnWTAKP9DSG5k8joR9PUeq9HMx6QFkJYwD+BLVrrVwshuoFfA0uBDcAbtdZDjdrY1wLSlRQuQqUZKQ7z5ms/wldf+T6O7DzW1OBH+Bpg+aEr20Z20tvaURWcKi1qkzkaHKEYLKzKQn9jxWE6Et3hyXJFVSDvZonLBB+/6mu85oUv4os/+R5rN23gpu9+j7npuXQle0hYKYpekaw7RlusA1c7rNy0mo3jGziwfSknLTnRCCelKOoCI84w81MLmWkK/PKVAc6G9wTzrmG0OERbvJO+4Z289IoLWHn1zUCpYmggPByvyHBxiIw7zls/9hH6BobYfM192Jbtf++wfsyUXO+IdzDmjJJ1c3zlR1fz8ddfxomHHsPO/A4sYfPzJ37FRYdfSMpK+yfGmfiAJWw/Uc4OXTJBf6NItkqrYCBvzqnePL6ZBekFdCa6SPhZ2c3CWSeav8pgc+AuivlumzBIHlEColncpiqrf/6C0rz/ts9w1Us+P23gg9Ca8dfCtuxmOuKdtNgmIB+1YIO/lTbMXCmPgXw/7YkupL8/o/GNqBvUVQ4P73yYosrTleykxW5lQXoxJ17yau7/3h9IxhN1+we1A+YTuYsqj02tR3s1WkkIcQXmNLh2Xzh8BRjUpTOku7TWH23Uxv4kHEbdYfKOw5UPfJf3HPsGlrUfSsyKhyiYwMcqEBzzxTdw27/9kK50p7nfhyqOFcaI27GyZKkyNAumqFlQaiNw3eQKeayYoFBwaEmZg2fiMo4UkqIy0MwRZ5AWuy109dgyRt7N+qUYPP7ft7/E7+/8GyouWPW9PzO/u9ccEqOLdXMW9jRVIkDq0UTMb+tQHy/70sXc/vkfk5JppJQMZ4dpTbaQ9TK0xtqRSDZlNuKoIsvaDyEhU6ZkhTRAgkw+QzweM/kh2mO0OIxA0hprNRtcCGIixrbsVu7a9g9efeCrGHfHyLk55qbm+6UYBBDJvNWlciUB2svx3R1BWQ5TDdicKieFRGJR1HkSVqpKkEyWovMWVWbMUb1pREXbSnl4kXiSFNLEv/wM/mhhycm8n/A6KiCvgUCgFOsIhFEU8RXkMATXhSRKQqwZn75GM1wYJOOO0x3vIWmny0uVTFJJaeaZjU4vjNJeKxyEEIuBnwJfBK7whcMTwIu01tuEEAuA27TWhzVqZ38RDtuyW2ixWxBIrn/iBv7y8CP85C2fJ2bFyzDqwfkAebdAxhvxSxBbSGHheEVufuAu/vzArfzX+/+DhEyECyrrjZOyzOb0lFc6cxiT2fnrW//AXx+7FcuyOPmgEzj/Ja+mLdaOo4tY2Ny06Y+86oBzyDjj3LvjHs5cfBZKKVYNrmLtyBOcMv9k5qUWUnSK5FWejkQ72q8tM5lCY7tljqMMqyLxqR45qhhabbXaG3NGuf2Zu7l100OcvvgY1g1uYuTJAZZ0HMjppx0FwsQIjug6mo1jT3No5xEBHzcxJOXw879fz4atW/j02y8HTCzg6sf/l8O6DuToOcfw5PCTHN1zLDEZZyDXBwLa4x1GEGiTrRuTMTzt4mqXlGWqxEZjNAFqigikNe9m0SiSdgujxWE6411l+TMBU54KBYy0bH516R1kvXHSViuOLvpwbK/s+NPKU+qq2gqf4/lnQZQskVrMtlLbdjwHjTI5OxFm6+gifbntLGo5IHwXji76hzglcZWHlIKYiJeBJRpR8Oy+7HaGigMsaVnqC8jypLuCVyBlpyaY2YmFQ3QOYOI1vjcLh2uB/wTagA/5wmFYa90ZuWZIa111kr0Q4lLgUoAlByw58cmn1+ypbu82cpWLpz1WDT7MsvZDeKJ/PcvmLKEj1hkWV5N+4DgwY4eKO+mM95i6Pk/+gx/8/ho+854PoMdjHLpoGVJKlPJCbS3QjE58z6t44Ko/hphp4xt12bBjC21tSZyi4q/b7+AlS05nbksPSSvFSHGYlJ1iJJ/huyt/xruOeh3fv/ln/P6m2xgtjPLld3+SN73wNQBhIC/Q0HZFE50OKnoFP85j18S81yKzN3SVpmvcEYoNY09x55p7+fWfb+FnH/kqg7kxBvM70EWLw+cfyoP9/+TonmNpjbVywntexUM/uBFbxsm7OdKxFjzlkXezbN+5k4MWHIhAsHl8Iym7hZSV5ieP/y/vOvJi4n4RvfHiKB5Gm01aSQSSrJshJuNYUiKxS0mOEfeSFBJHFfGUIi7jaKFxPZNgRjgPgW/baMrNWFb1KBQOvlsrwOuDiRspP5HPlnaYVBllevWSw4LrAqEVjY9EXa6ecsvgnjk3Q8o/vtV874VxjdDdqjHwVM8lq7N0xDrNe9dw96aHWdO/gbce+3IQhAmazWj8Qb8LboG+3DbSsTRPj67n+Dknhu/VzJk36cTEXXE7BbRX5jkIIV4N9GmtV0zlfq31D7TWJ2mtT+rtnTPNvZsZMpslRkzG+GffP+ltb2ft4Ebu2roiLMlsYIBm4TuqQKvdHm6+4w48mgtf9Hq6Et0ctGBJJNhdOjc4+Owr7/lEiJoy1wiGnCFaOmK0p9uZ29XDy5e+iLZ4Czty28i7Wdpi7dgyRneyg5cecBpjzijDxSFG4jkufN35HHXgoSU/pyD8V08wmNyM+sdBFr0ijipOy9wapmn6MeoM+4l9jckEAGv33dOKDWPrOfHgY/nA2W+jLdbOge2LOKz7MHSiwKgzwv9d92d2DgwTs+J8518/h/TLlwRMwTD5NAfNPzAMtvck5xC3YvxszXW8aPELSdkp8978iqHDhUEKXgGlNRYWGlg/uo7+7A5Ak/OyYaVbMMzC1S5agSUlji7iKgfbP/oUn9ka95IRDDk3s0tWXhA4HSoMkHUyZW5NACkEY85I2dqbKOAaMPEoKCG43lFFHK+0TtYMrcbxiuzIbTVoPD8W4/i5CQE6KAByCIRfXsYiZsdptdvCsixr+jewettTHDN/udmfEZhrkDE9EeXcLNtym3lyZC1ZL8eiloXc33d3matqOjLWp5tmUp07HThHCLEB+BXwEiHEz4EdvjsJ//++mevinqNowLNVdfGbv/4JrRVt8RS/uv933LXqgfA65Se96eBvZSCprYl2zn6eOQcACJPihDAaXOA7VVrxkuNPC+GOYJhxi92Cihxo35vuoS3RSovViusXLBvLjvOt667m8O6D6El0c0D7AYz1j9GebuOwAw4uM7eFeWhdxEvAjGrB7UJNUjfHpOq1A/hJYF4opBJW0kf3GAEU1UCbJYmkPdbF5swWeud0ctO9t/PM2Bbu276ClN2K0oo3nPYqtJ9UdcbRp4TuktBNJSgd4erHbCxpY0ubQ7sOYnHr4jIGkrCS5thXBI5XZMwbBa1J2MmwRLf03RSeMi4Xg3ACDxeB8A8r8q1I30UZJMShQWjhQzPLYdFReKWn3DKoZ+XcB+8+ZbeEReqEEKaYotZoDUmZQkQSvJRfpLHR+63MBwjIKEthVI2uRA95leO/f3U1BaeA1oqcl2PD6AbzDFHaE8G+CARGwcsjhcVArg8hBEs655L3RlnU2Y3EFLgcd8ZZufMRhovDFLy82YvBXPhCCAz6aaw4avJKhGRJ6xLSVgs9iV4WpZc0JVgaUS0Yb7Ow4mZoxoSD1vrjWuvFWuulwJuBW7TWFwJ/AN7hX/YO4Pcz1MXdTpUQU095OK7Dkxue4ca//IN1mzah0Eih+d2Df/Xx9SXIoSWMi8Ro56a0cbBZA6RH5TqIIkgChqC1QYNYwmZuah6S8oqqrfE230fusjmzhTtX3U/OydAWb+eYA45EaBjYuBMCYRCY7BNon1E4YuWCFUJgWzYxK1bGmCZLQYnmgEkCJK0UluU/Nzihr8mmgzkBOLz7CIYL4yjL5bf3/oGCl2dbZjsFt0hvai4vOf40Dl6wJHQ/CG1qUCmfcWttBLvjW1Aq9L1bHNlzMC12qszVIoWkBo19LAAAIABJREFUNzWPhJVCSouiayrndsW7aY21h+9dCHwB4YZC3RIGbmmsBBOfQhurLkBZ3bPhYT9onSbrZkIh0J/rJ1PMlEpV+wzWxxGFc1f5fuIyTtpKlykIyv9pi3f48+9/Hmbj134RjfItBDI8i0RrTcJOIIRkeCRDvlAMz6zoz/eXMXFfu/JzDazSGLQm5+VxlUtMWrz5uFewPbsdKS0/z8VhoNDPSGG4VF4+sq9c5eEpj23jfTzc/yhPjTyNpxSLWhYzJ9lLKpZmafvBdTOd6wnljDNexTOmSs3spb0xz+FK4GVCiLXAy/y/91uKviRHFXCVx8Vf/n/klMMHv/l5Htn5EMt7ltK6sN2UQNAuQphMUktYoY85MHctv2pn0SsQs6vrt0TNco0JmGo0WmikMIe/pGOttMZafbPbXL+5fxsZN8Ovn/oD3/rwJ0nF0mgg1R3nBa84BSksYlYpKa/MfyxqL0ZR8TPR/DTSiBq14WkvDAJGg3UIv5Bg5HzdZjZdIPySVorzl7+ewxceyuVvfxv9+W28fvk5nDD3BFJ2GhCmcqgQoZaYdcdMkFO7kZiMSagzXZIILOM6IsLEMCXSLWnjKqNFJ+0ULbFWOuJdxGQMRznkvXxoGRR0Psy4l0KSsEsVXIMxAH7MCd53zX8aS0dAT7KXMSdDQeUYc8ZYNfRoiJ6ypO0LFa8svlBv/oO4U2AxFVWh7DvhZ0w3wvtXUsAko2MJBNdIYRiJ5HuXf4lUypy9nbASnDzvlBARFVVgFCWhl7RSCCFY3HoAaM2W7Ca6U3M4vveE0PVlyxjz0/NJ+kLIljEjZLTJ6HYcc8b3htHNfPveX/DTB69l7chToaAOBUmd9VZvDoaLg2Vnok9FQEy038qunWko63TQvo5WgtKLHndHabXbyLgZxpwR8k6RBx5azYq1q/jiuz7ESHGYpG1KYaMh443RZneEZYQdr4ijiyRkMjxzILAuguc4yqBEtue20JPoxSA3EiF+29OK0cw4LWmDo0fA0RedzbVf/2+e030Uo84wKZkmLuO+7mhq2Ac4+YCMb7v5AmH1UCZRapZ5TJWMK8YtCxY2IiNgHUaKw8RkjFb/3GcpJP25HbTG2sLCeLXKZAOMO+MUVR5LWrTZ7SBMkb5AsyyoHAmZYnu2j+vW/ZFTF5zKzRtv4zXLn8/c5HzmpOaG87JuZA3L2g24L+dlSFrp8BjMWkljwZw7XpFxd5SuxJxw3lftfIK7tq7g0qPfXFXhlQmC+pXXaa0ZdUawtE0q7udTTDHo7XkeQpYEbgCoCHKCAkivUoobnvkdZy9+pUEbaYdxZ5S03RpWHBYIPzheWqdh4qjvynK1Y9xx/jvMOhlc7ZL3ckgh6E7MAS0YyA1yxncu5oLnnsr1193Gu999Pt+5/rcMrNzBx9/+Xt53ztvDtQCQdTNl1YengyZCM1XSXhmQniUoFEsaVM4vhtfqM4e03YLrKb5xz9XcPfgYV7z5nWTdLC12KwmZYNwZZe3o42wef4YnRx4HYNwZRQjpJ9/YJY0zUphu3BklJuK85U8fZm5ygQlWYhAeQb17Vzt8+if/xV/uv5O+/HYcz+HO713D8o7DyHkZ0laaoiqwbuwJnhhew93b7sEW1cz02nW/ASKm8QSKSGUBvd0tCGqRFHJyxzhqY611xXto88EBjnJwlMOc5FwSVjLU1CqFnecX0rtn+/080vcYrVZbmPEuKQVrE9Iw095UD+cufzlC5LjihEs4tOMIVg2uZsPoBtMVrUPBMO6OEpfJsI16gfUg3mBJm7ZYJ9tzW0PramnHQs5Z9sKamekFlW9Kcw2yoD3tsXZkDSd9/YLwvXraM+d8TNJduGrDk5z775cghAwFqKddY40JaTR030VlY0px7MhtRQqL9lhXeI8Bcpj6XoJq6yfjjPlWealuldKKrDfO9twWbGHTYpmzqcfdUbJ6lA+84lW86YTX8q63n8/qjZu54IxX8qH3X8Z7X/X2sOZSQKndlPczFfdrLXrWCYep+q53Rz8+8K1PseKJRwFIWaWNDIZJLWpZzBWnvwtvdIwXfOrtfPmOq+jP96G0otVu46DWZVjCYlHLEhQeSTuNLW1SVosppKfypfOC/Z+WmIkffP2FHyXrmSxo4W8NKcyBQjk3w6cu/iCnHnkC3YkeiqrAWZe/DYSBOHraY3NmE0taD+I5nc/hxLkn1kQkHdN7tBlTZMN5DYJwtZhQ9N7dKSwKXoH1Y2vNcyL5EI0YoPatJle7ZNwxhoqDaK2I+cdbIkqnsNWyiIIYwWnzn8cxvUdiSTt0dUhZuif4zBIWC9OLOKzz8PAZh3Qsp90/TzrjjodtS6wwgasRA7aw6cttC5/THe+h6JkEuZSVZk6yt6a7p5LR1aNg3Ukkz+k8ksGHtpB1x0OXmhSWAQVE/ewTlOw48qDlfPV9Hy+zPCxhExdJJDI8VlQKyYsWvRTbitGT7AVKcRJjEbh+Dw3qa6w4EgpGT7vEZDxM8Axhrwg85TE/tZCOeCe2tLlr221GiJDigY3r2fDMdh6+60k+/sL38m/Pv5i3PPeV2Hb1+ewAWdfEEXJOpjTGSPwi+tlkvDzT4RF61gmHmdBG69G/v+0yFs9dAFCm2QVapotLT3IOHzv3XzjrlNNZN7qJnbkhfv3kHxjID2NbcVrtVi747L+S9/K4qkjOzTLujBoNVFgQuGoiqAyFoiORJiHjFLw8trQNM8JU5WyLtdORbqOztT1kbt+6/NO89hOXEBMx+nM7mJucR8pKgRCk7FRN98DBbctLeHutybhjZZDDSqoXxG7WR7orFJdxehJzyz7bMLaen635FU+PbKy6PtisrjYnkMVlwj8atlTXJ4qCqsUYbGGgkQk7SUe8nYmGGMxPOtYSBqjnpRfQFjPHvabsNJ7v105aKVzt8vToWlYNriKsu1RBHh5diZ6QgceseOhCUpSfclbZl4bFECusJS00Wit+/PEvhe17/vkGATMPrp2oBLvEYvmCpWVrJSpQg/XuKRdb2jheMay0Kv0fBKHVEMQh0v48GsisRXCCX94vLx603ZPs9efaY2e+nzmpObjKpSPZygdOehunHXYSF77kdSzunEdLvIWFbXPLqgkH4zRWobEsbav6IKK8lyuDcvfnt9d9j5XznnXHm4JrN6JnnXCAvUdAHDDv/2fvzeMtO6p68e+qPZzpzrfnKd1JdzpzGKJhBpnnoAhPQRDwifgQRBEU/WmUnw8lKjIoIo9BnuBjloeAMkRQIYGQEKbMnXTS6U4Pt+98pj1UrfdHVe2z9xn3PXfoTvR7P/fTt8/Zu3ZV7RpWrfVda+3E1snePhqu4cVvH9+BNz3zl/ALl/40RrxRXLH1cggzMQIZ4vpbbkYQN/TSTh6IddA1G34gPaAUq4TTbfVOrFrhAbTB0UsMmYCO4fOwAxfhqsc9DX/44XdjxB3FZHFKp8JMqa/aUUxtGgTCYlDFdcdvXG23rQo2IFo7iAhjhkFjsaW0BZdvvgROl2li2V46N7FW4xWMNN0rr0a3ZwrhJGG1hxmXnvCStJf6pNASAlxysTTXwOe/8TVd5y4vyiGR6N/t4/UJRiC9W9kTdzuJoL0v20/mNhR7KAM4wsPuPVvxiTu+ZMabXsTbQ8rbeywiGWVOcQ1Zx2K0OLBvEv27PY2RgBDCOIYqHZ6cKRO2g5nx7u/+PW6cuREz8/P4wBc/gYVgzgQ6NMQFE15kydiZjtdO4Gv3fR0e+XjktotR8sp40sMenZSZ2bTa+9+cFrupMn3hJ/4tgA4Jnvc8YNWZq8F/ys1hLTEszXKQNGwHVsktg0DYM74Dzzr3iThndBf2T+zDVHESAgIFp4gXPuGZiCKZONGVvREopaCM5BDJELPNGQSxtnEoE5SrGtRx06FbEakYQdxEEDcQygBhHKAR13HL7O2oBjU0ogYEOXjFM1+E2aVZjDoTcElTTEGA53QPL9GOMW8M9y8fh+QWO2g9kaEtwtIeW1J9x/XgzD0VbwSXb7oU54zvzl5jfqTJpJfEQBI+MpFR295x+/tOS5CO6K52aH9mv+8sHdT6N1SDOpajCAsnm0h8CpBVVVgHyaRqDLDSqhdNeRUd6g2LdF7kpE9TtFY7PvQmorAYLKAZNxDEYZLcJpZxQjeWhgJq+8pSZ22JoYzw/ZO3Q6oYjbiZDeMNdLxrHXwuxaoy1FVbR4L2kZAscd/yvfjcdV9BtVlHKEPMN+dRLJTwnTtuxq1H7sLnvvlVHD5+BFEcQZnnOOSi5JZQcUexEC5CmWcn4TxSY6ndl6bfyciOG0e4CamEQBjxRnNHGnCFl2y6w6qYHjKbw9lgR1gLtC9oABJ9pyMcOMJNfB0AYFtlB973hj/BttHtiW5bL9aMQAWIOYZkhYVgHkvRAkIZoB7VEXOMIArwmg9cjVDp0BLff+AHiGWMWlxFPa7hjoVDOLR4GIvRgon+GeFt/+NN8P3uuXjbP2tvR9H18eLznwuxSokmL8+73dEJMItOSgIc+KxeGz9D23QQmwU2dRIQbiYce0e9Uj/tn68UnZuP7pumaiCSMd513d/jnb92daI27PoMypbD0P4fzIyjM8f1gp1aWDv6re2/pDs8+c56Jc+Hsyh7ZfzSpS+GJzwoEwE4UA2T/4AzGeCU6XtXuJrBBcZf3vAREAlsL29Pws3Uolo2MB7rDbseVyE5Rj2uJpuFhQ2lojdViSPLR/Chr/wfnF6cxW9e+Uo8fffTMVIu4c2veiXG3Sn89t/+Cd756Q9DItK2N3IwUZyCL4q4YssVePyuKxNaeUf3pj5L+hLav0KxSvxe0o6FSVPWwKfBlrNS5N4ciOhxRPRK8/dmItq34qetI86UqqjXRF8N6rJ7+AJ7NFaQiUepNcplQhBAL1K+ib/jOT72jp2HCX8SM82T+Mr9X9GGZShExCi6Os/CzPFlvOX9f4aSV8KYP45n730q9o7vxJg/Dle4eOO/vw1v+dY7Ogys3dqelortv67jZVRNwyKPg126bsmPua8ua4bZ0sW7NFXfWMWZ8B725AEgUdto6bSlHliPcZh3jGlbh1bTjHhjmCiN4lMvf0dPlVV7ufYEIYRIorXedOeP8JYPvN3e0PpNPTMx1lK2/+w9EhIhhzgwfhAXT16e+DR4wjf+HgKnm6dAoCQfOoOTwJC2/KJbwN89720QghCpAJIjnGocx9HqfTi8dLc5CZF5dxFuPn0TGrKGcX8KChKzwcnMuJxfXjCbj4fH73gCvvCHH8HmTRNgaFvSfdW7EXGE/Xt248d/92W863VXg9Ha7AiEhXAOihkHxy/uUI+l+8OquALZSE6aRITFcB4SCncv3QGGtsu121I2cr5k7sspgV0NHVb7IDOfT0Q7AHyKmR+74ieuA9J+Du1c+Qcj+rWBwWDFWGjOw/f8jM4ZaJcAWyGJrd7XRsEEGBFH8FCA57T471JJ3LF4K0puGXtHzm2VRYzDy4ewpbgVFW+0FfwM3XnVaUczWy/mlprB3tte542ArVuvPo5UiFjFqEbLeKB+FDsruzFd3Ixm3ETBSUWXTU2dbmX16pu1RuZUpFQSksOqalzHXVE9GFo9pKBTyYYyNBtGi15rn5ennKasYyGcx6biVrikN9GmbOJLRz6PCX8Sj9/+JISyiaJThiMcRCpK1FnaOKyFEcUKM80T2FLcrhdoIXSyo8SHRyVqMmaFuqy1ohWrCGW3YtQ7OrnVH37knThv1y689Ck/DWHyLtTjKhzhouiU4JGf5N624ebtxiOMyi1WcUcmt25IAj9aGm2KEWfblm7zRmEt/Bx+GsDzAdQAgJkfgI6ketZBQfUM5vZgwaDBoSDx4j94HarVJurtR2oDK+WmpUIBHZ3zR7M3wxUeCqIIz9VObsvREk7Uj0EIgXPH9mN7eQdIEGLEyYJ+ZPk+zDRO4t8f+HrqQX3aQJ0LiOpirF1L5LEBdZOkYhVjPjgNAHDJgys0a+vA2AWYb86hFi2bSKidUl0uZ7C89V+F1ysAhNzM1FFyjOVwsPG2vTz7L4PhOV7GCa6DYtlDrWjVO74oYktxO1xycaJ+1NzPeOau5+DKLY8xJwbty5GmXn9/9kYsBDrPV2w2jOnCloQp1YjqYOLEGe50MIN7l+9GUzYQI4ZPBRSdEnxRQMktp+qp39nvv+x1eM6VT0nGsEMuXPIw15zFbPMUAtmEQy48UcicmCwZQauqolwbryf8jo0h/bfdXM4mwTbv5hCyfaMAiGht3frWEFrKeMiYUrpCkIP3vP6PMFqu4Kff8hrN7rADFi3qpFI6K5nNTOY5Hlzh4bzx840UYw1WCvctP4DvnboVAFAQxSS/M5hRjZYAABdMXogt5e3YWm5RPhVUX8pcu/S83u9mpZL6oUUd6t0VbiYDmEsePOGj4BaxZ2QffFHs4LvnxUo2iEE0zkFIHN/MAuiaBa+ff0k3pNtpF65QBVgOFxO67CDY69IpcaeKWxCqAMdq96PsVVB2yybfRIyGrCVjWLLEhROXYNTEjDpSvReRjEyIGW1HqMZLieMngTDmjmFbaUfLME8qYSqlVYs2eZDnepgenUpyWAgSKLsVbCvvwLg/BQYwF5zuoPO6wsPR2hHctvDj3G/Wjp2Z5sm+dO6zCXln6ieJ6G8BTBDRLwP4GoD/tX7VGh5W924xDJPobIYd4Ad3n4uSX8RrrvoFI8V0OT1AMyosVc9y8B+oH03SHZrpj32ju7G9vLVF9zMTzhVeslFMeZtxaukUPvjpf0z0srGKei6T7YuofTdr8U66lZGoi1aweFvnKABZ9RxZOrCDglvIHU4jjWFUSqvNk92u3lBgnfVNZenMgzaghKprJVuIhJ1D6Tr2KKbFzmmpfQDANeHBJ/0pAK1F0xO+pmGbXiMiHTXA/F1xK5gNZiBZ6nDfcFEQxcTZj4hwvHEcgbIOfzq8RtIO8/+0vcyeuEMZZPwJtEc04UTjuKaTtgkERIRxfwKbipt1DnSjasqDMW8cQKe3/GoQq3hdNpxcI5GZ/xzApwF8BsBBAH/AzO9Z89qsByzDIufLSNPO2ml/Zwu0lKMH5Qse9/QMwyPDbiArKbmGJhhrD14q6LAZqWtH/BE8fOtlHWoZQSJZND3hIaAmbj52G4IoQBA3sWwc7rqBe/zYiKGW+thO88uFFGUy8/EKpe7JwnTmnevYUt19IYZBv42qvV/MDUOpFjrGq+lbq8MPZKOrx23CDFIKzbh1jemNzD0OORDQunY7p7qx0iwLyQaAjGV2rDnkZPvdqED9xJ5DINanHgmFSEYY8ybMIg0dWM/kDCk6xYSJdLJ2CgvNhUTN9I17b0TTRK61aW01O0i3tR5VEasItaiGUIWptutIuUFcx8J8Ddff9j3UQx2l9kTtBKphFSOuDk7pkGP6Md/YK7oluE73SMQ93+0AxpKNrLtWYzYpN++FzPxVZn4TM/8WM391TWuxAUiMoMythanbdWuoP94QsE46QimdcDJQuCWJMhRCY2g9b3w/PPJy6cyBlu6ZiOC7Pp7+nMeYRDGE+6tHEhpeNypeUk37ufkqMnGc+nnZ9q3TkOqdbieOtLqIAUgjBZ6pU2e/ZzbjZuIXkAeCBMb8CSxHS5lIpmkJ2j6vLmsZocDqyDMLP1o6/vYNOt1fUsU6FDkrhBykym0JEunr0/86pBMRjfpj8IU2CnuOhwl/GovNGuqyjsVoHvWolkj8rBR8p4hQhslJ4qt3f1v76Jg5IKzPAyQOHTuMxeY8AtXUzCelbWvMjEjGCFSAnSO7sRQu460ffSdq8TJCGSJQTRyrHdXB/tA6fVhDez+k5+VKx24/pCPuriX6spWIaBk9D44AM4+taW2GxEqisipWOFa7D7tHejNxAxmg4OSLHbPRaNfhM+vsXw45cIUHYZK3hDIw4YdbTIqa4X3b7HG9GDZAF4etLuwjAFgMFzDTOIk9I3sRqxgFp9Az+qfNGbwWGIbV0attDybMBbO4c+F2PGrryoiCkYwA0lJ9Yk8agPY+5tZuYMpSCZOoV9+mQ3oHyswrRsLQSY9nRiudLIEMTViPU6UkFoNl/Mzf/yY++bI/xb8/8G/YP7EPk/40zhk916g3yUQndjSt1Jxu9P0KDJWwkj76tc/i1Nw83vTfXo3Dp+/Fjsnt8B0foQwxE5zE7speBDLArfM/wi2n78QvXPAS4zwqOiireWHbcyZS5vaaL0OzlZh51GwA7wTwOwB2AtgF4LcB/PGqa7xGWImxTZDAzvI5CEy8lDTsQL5t/hYsBgtrVr9h0E96TH9HRCiKEqSZqBISsYqSBSB9kiAGfCpkdMlpj9K0ZJ95Hmu9dTVeSphgtq/G/QmcN3Y+fEczQnqpmIhMYvY1glURrAQbuSms9RHfYqowjSu3PGbF951qnsRNJ29shcrIiXQf2/6LOWqx4brQetOwEnLEIb503xf0JgVNb1WssBwtJlFb23ONpKXrLx35J4wVRvGhn3sLpgub8IJ9P4PLph6JPSP7oFhpwYgceI6PKNKJnWIVYa46j/Ne8ng0ZRN3LtxmNguBX3zai/Hm//Ya1OIqXvuOq3HzoR/jSPUwfFHAqDuKSIUI4iYOL92LZ+97enKSWs3Cno6vNCyGPc1GvHKbRN6WPoOZ38vMy8y8xMx/A+CFK35aCkS0m4i+TkS3EdEtRPTr5vMpIvoqEd1l/p0c3IiV7eRCiK4S7KnGCSwGC7ho8hKMeIOZuuutcshbvhBCR3UlmBOEr4+8YASyCckyRcvLJgA63ZzDh2/9GBiceJy2e2mHqplRyYQy0OWaREEWg1RUa3nstfl/V4qN2iBWyzrqh2H6cXtpB757w+14zz9+eEWbavsplUCJ4XghnE2+W46Wcf2Jlq+RhTShK043TuHL9/wQjaiRlOyQQFGUk0zOGTAQyAYUtOB35dZH49Di7dhW2oHleBFN2UgEn6VwAdVwKemXZ7/lFbjlxC3ai7kyjm/91WcgiDDqj6IRVyEgUI9rWIoXUBQl+E4BX77/K5jwpyFIIOQIAg5ONI5hR2U7xj0dc2slzmS95u6qHdqGHL/DCGZ5NwdJRC8lIoeIBBG9FMBqCesxgDcy84UAHgXgtUR0EfQJ5VpmPgDgWvP/vhimv7tRKjcXt6LgFHHNNz+M6x+4IRcDYKN10t10lcyc5Oq10BEn2YTktsf6Jpqynpm8m0vTePKuJyTS3d1Ld+G+5XtRj2uYC2YRyhCeKMAjHxV3REcSFb6WQFOqgZVK8f2QNzTGWmw2tWg597XtRtx+WC3raK1xtH4/9lwyiYsvPDexIQ1qR3sf29Oa9WEZ81py26g3ioMTF+rrWCbsHUECjbiGqcImvPmKX0LR0ydaBw4AnUjnRPM4QhWgHtfQiOvJs/QmpPtxqrAJe0b3oeCUUKRS6mSsUHFH4bvasxoMfOCN12Dr+GbNvIPA5PgYmnEdk/4mOOTheOMY3vHZv8U/X/8NxIjx33/hBXjaBU+ARISaXMaUP426rGlH0NF9WF7BGEljvdaGoYSiIeZK9ySmnXgJgHeZXwbwLfPZ0GDm4wCOm7+Xieg2aLXVVQCeZC77CIBvQKuxBsKqT4bVCTpCMzFeeNFTUfJ91GUNo8LtqZ9fT6xkABBpdoe9x4FjUh8qxCwBYjjkoRZX8Q+3fgWP230xLpu+1KSyBM4Z04HlmHWKRUc4GDfGQGGpwemQCWgxJOaas6jGy6i4FYy4Iyh53V1gVqLvV1Bm8Vh/+H30793qrFjqk+qAZpxNzkwAsK20HZduijHijxgVjqY2t9uw+qF9w0vPMyLCVGEaUmmdvzVaExHmwjlMFzZj7/gunVCKGfPhLDYVt6LklHVuawgIx82oiOuyjgpVtHOa0L/MDN/VodG1EJHNfSFZ4pztO8GssBwvwiUPDnRMMs9x4YsixtxxTO/dhNONRTArPGbvldpWpyK4rnaAPLl8HDsqOyFZYaZxElPF3tGTH6rIS2W9l5mvYuZNzLyZmV/AzPeuVSWIaC+AhwP4DoCtZuOwG8iWHve8mohuJKIbZ2a0Z6se5P1pXznqggPT52DP2E5898QPUY87bRPJtW1SfC82TD+sVrqwzyNkcyMDpPnbbJk3Cl/84XWoh0to2uirMkzUR5FJuOIJD81Ye9l6Ro9ry1VKqwc4ZUgsuxUdosFEt7TlBXETkYoyDA1rIOxrT0nZQDYCnkkx2f78TJ1snc1Xa5XkfSPhOz72jZ2LzUWdUjT9XvKOQXuSSBumO+/V/485RihDgIFRdxQA43snf4CFYN6w2mxfM0b8UXiOPuF6Jh9zM260xnTqOZpVJhKjtnVgU6xwZOk+zAWnEXMEEKEe6VOyIGFCWGu20lwwjy1T4xDTjKVwCWPeGEb9MZTdinmmDnntkqc3rtQc6IZu/Tcsk27Qdxs57nKdHIjow+hicmLmV622AkQ0Au0/8QZmXsqt02N+P4D3A5qtZMpK6HerBTPjeO00GlGAits9nd9asV9WIr0BOgRFohazt6VCVejpoydyIJvwxTgYjGMLp7F72xS2V7bCES4iFcAhx9gaIiyFixj3xxFzjDtn7sNl2y7UZVJLpTLTPImp4jTAwHxjEZ7jYu/ouUkSIQajFlYhBMFRDCFEkg4SpB3NnJTk3e1922QsG8UuImrFfQKQ+bvz2myugWFYUxbWOcvWYa2RsQchtbCrVpuJKGEfDVM+MWXGoKBWmOhANeAJD5PFaQDAkeoxjBSKmPAnMeaPa3YRJFjp4HcEoQUPUzdPeEmQvjS6MqigczLX4yoq7ghIaNaeFnB0kERmbUw/fOJ+zNRPYvf4VhxeOozyVBklr4ySW8H3774Fl+y9ADvKuxCoBpaiBewo7+rbr7a93erWa+ymDfB5qeQbjbyK0S8A+KL5vRbAGIDqah9ORB70xvAxZv6s+fgkEW03328HcGq1z1kpbMjll134QmwuT/V8eR1Bva2EAAAgAElEQVQewKmfvBiG76wX4bSHc1s9iOA5vo7M6U+BzMbxpqe8HOdv3YMTjeM6rILwECidber7s98DkY5Ps628DTccvQXXHrqhI/TAgfELzALAuL96DH/0H3+NpWixtbCCcbxxDDFLzb0GYS6cwQ/nv4evP3AtjtePGhuF7Nqv7XruDvvKGk+S5ORln0nooOum25/2CF+t3YOgYwQNU0a3hEL9npP+WyI2B7lW2/tKxm12FtsfPY2u0P4iY/54pm0v3P88bC9vRVUu6TwlQhu3HeEikI1MgqqyV9HX5PAdALSa87zx/Th3fD98oQNSjnpjOpierCHiyHi9u1icreK2bx7FY7Y9DkW3gKO1I2ClU4O+6u1vQiOuoSa1nWFneTeqbZFS2/u113vsN69jlbVnDloH0kLEasbcSk4duaKydtykxdavMfOTV3xzqwyCtinMMfMbUp//GYBZZv5TIvodAFPM/OZ+Za3Ez2G16CUprlT632hEMsSJxgOYKkyj5FbwL/d/Ac/c/VxIJROamyd8nG6cQkPWsaW0Db5TgL9C6uMgWON1I2iiUiyvuM/W+jQx6L3ZhdFGzDxWP4LpwiYU3ZXXfS2xHGla8URhasX31qJluMKD5Bgu+T3zEFjojYgTFU4e3LFwO0IZ4tLpyzKfLwSzGE/V2TLpyk5F+04k/giiJy06jUZcQ6gijHpj2vHOqFF9UYBSEq7jIebISOlkFnKJpmyiIIrwHR9zzdMY8UYz4VOA1rtXrJLw4Znvz/I53w2avKKSeFFrEZW1HQcA7BnyXovHAngZgCcT0ffN77MB/CmApxHRXQCeZv5/VqGXX8WZOPrlhSs87CzvRsmpIFRN/MTmn4RiCSfxrNbpQyf8SYx4oyAgk5krLwYyYKAN3J/6+hdxzcfftzL7zAoFmbzXK5Y4WT/W/TvoEBBSSSgobC3tAJG255zJ9z3ijmLUGx98YQq2vh4VdJwkp6IT6Qy4vt9CbX1g2nH++EEcnLig41pPFDDbbCkDHHJQEAU0ZR2BbGg7AhxQzqWp6JTNeNWngoIo6phLJLD3zc9EQ9bgkmfyqevggWCgnGr7ZGFan6RSjDuGXkRr0TIastYz0nMu+9lZtC7o/s2ZTS5nge2e0ieQk0HUC8z8TfTWdD5lNWWvN842mmIe6OOonuA+FzFV8JP4TFJKzAezKDhFRCrEpD8NV7hYDBcw6o9BoBXpMw8GSVQEwouf/BwcOXW8+/09Tmc2umxuD19wYizvV5daFOC9P/gM/ujRr+/4XsD4xFBLb2+9gs8ktH2t94Kdlg4z30FH52Vou4r1XUh/3379IN8VF17HM4moI1ihgoIvfJxqHsdUYXMikQtyWtFkV6g2IaIMsy1Wkc6WyBJf+60PoOSUE7WZRGzyM8QY9fVJQ0Fvfh55SC9HVojxhI+Iw1ynmHZYO5219bTPiWq0hBFv44NM5O3fXJsDM5+VuRvOBPrZHx4s0NTU1gZXdspoOnUUnRKOBnMoiCJG/XHt8YxsLJy1amfJL+HAznO6fteLyqpVISvTteeZCCN+GU/f87iOz+0Cak8KWv0ijISZNWKfTe+fiCC4twBjQ1eAs8bOYduQJKkZUJbeVIGyO5Jco5QEzIawFmElGIzDS4ewubQFF24/N9kA9SnZRVEQ4iSUuLadAdovyKFsUqSTtVm8+9/+N7YGY3jdCzT3RiqZ1HVQfw0yJNscFmcrcr0NIro2z2cPFaxUfaFYDR0VMcN8sT996GrrQWMjEhj3p+AKD1OFKYSqCVg9O3SOW6SoqH3LssZK7pRAs8/UagCpZJJIvp0FlLnfUBI9k7xdp/DsHz21n3SdLlcqicfseHjPa/RCyh3hRdL01m79kn6f0uQJbn/fXa9P/QwDZkYjriU+Bd2QMGXMAqZUi9paj+q4f/lIsnnkgSUudKtymskjhIOyUzZ1U1iOlpJ/q+HSitrY+SFMjvQagrgJTtOooVVYDnltpxQTlM9GmjXvWbHEZGEMOzZtRRjFiDlGJCNzXef87NnP1Jm7m5lxeOluUJ/7zgb0PTkQURFAGcAmE8bCtnAMwI51rtsZw3qqDHotInkm4UoGkl2U8khjmt3kwWEHYzSBUOrNQUeqZDhOdoHNW9/FYAEj3mhHBFAtMaqERqmI4QBGOvezMXbafBASFYGxlwxrNkt4422LcKgCEAuT1L51vSNa3rrpwIKKlaZzAmBqSc03HrkFF2zdh7JfTBbgbn22XkbNUAVwhNuV2m1VRclzGWCtYAGgF9HDy/dg18hus9ErqNRY6qUmsd9lntVFReiSh0A1URRFLEfLqLijUCyxHC+h4o0OnH+JIMHZZyqWmA3mUPYqcB0PEhKCHQRRgLnmEraNbNLviAGobPa1zDtVmg/oOx5+9ZE/h/iRMQgEyRFcuBBdnGx7Me/a6yxIU7uXwiXESsJx1oZ6vx4YNLN+BcBNAC4A8D3z900A/i+Av17fqj14kOSQTdE586CdhpqmTHZMMjuhc25c3aT3QRAkUHS0SskhF8oYqduNg90WBXt6SuOe5UMI2yh7SdeQtiEkiYWI0JD1Vpax1CMsTdC2XZ8IRG61UT8QEVzRCrccqxgP1O/voNO6ws144qa/U1Ad6qV/vfO7uPaObydts2GkdRe0NpFeVOhhKM7pNk0UprXjl32mDZTXVm5kQlw7JuQ0EaHoFvHEHT+VLJ56YUuFzkB3lUmuBZK1T0M1WtZhsSvaO7/klLGzsrurD0OvE1Y7fVRB4VTjOMb9SUwWptGU2plzOVrGyz/+u2AoNGUd1XjJ5JvoTae270uYfNw6LHZpKH8QW6YggVpUA7PCpdOXZ/ORn4XIRWUlotfxWZzcZyOprP2wnk5bw5Rdi6pQLDHqr4zVAuhFg4hw38J9msFUGEXB605rtYwVxRK+UzRpHyUkx/DIzyxQQCsOU6R08nbXceGRn0hv7VJpP+m6m2Ta7TOpZK6wKs24gcVwHlvLrYNxe6jldH3Sz0qrT9L3tPsIDHqX63GaSPsDpHGkehjby7sSdd1aoFf9YxUnar7TwSnccPLbeMrOpyFSMRbCOeys7Mn0sUV7WbGKsRwtYrIwnX0uMxbCOYx4o/CEnxjJwTpHx1K8iJnGDPaPH9QCQZ8xln5HsdIZD23Qysypa4X4+rFr8fBNj8BEYWA80Q3B0FRWIrJ+DMeI6Gfaf9e8pv+FoaBYYaZxouOzsltBJUd02W5whQeHXLzumrfiwEt/Cjt+udNga8Fgk3O5kEiHBM1iAYAfnL5R65ih0JRNCHJwonEcx2pHUXZH4FNxIBuk12kskM2OEwtDoRpnfTRngxnMB3MDT1NFt4RNxa2Zz2wE2IyKK6WOsjm0GdqRyno+ZxYQa5vg1ubYLhkzM2IZZz7Ltmt4/bRimUmFaduyu7IXbjfV0yp14d3quhwtJifgCW8Ku0Z24XD1bggS2FzcmnvBdYWLcb9zcVVQGPMm4JLZ6AggJixFC/jqsS8jlAHOHdufaW/a1pVpM7c2VMUSDdlAoJqJEJQX7f34hB1PwtgQwtqZwCC10hPNv8/r8vvcdazXgwYbZVDqp2YQJDDRJkXdXz2Cu5cODc0AIdJRXN/7W/8/fuMNL8Efv/aX8LBffhYUK9x57G685G2/htnmDAA96ZfjJR2DRsfuRMwxJGIoKJw/cbFRW4gkFeT28k5sr+wECeqqrskLHTMne68gByWRpbtuKm5BxRvBUrSY5BToBSHapH0jLabDcCeqQCKItpNCou4yTBkw0JC15PNuVGirJvmzGz6Eexe0z0WvOE/DwDEe8fZ+25ZeqsqII1Sj/AbiPBjzJ5JNVnIMV7iJ34iE7Kqy6Tfmu0GiFXYe0O+n7Fawf3w/yFBT05J/La4m4yFQQSLcSI6T9+QKD7fNHsJ1x240jKb8c0pBZXwk0va3YbAaosJK0dcawsxXmz/fysyH098R0b51q9WDCNVoGZ7wUHRL66JOyot2tcCOyk4srTJhkS8K2DW1E6/6iZfh5e/7HTzxGZfi5OIp/M//8x5ccOkuLITzWA6XsbOyCzHH2lCpGHVZNY5I+uhedFsLtVUrCBIou+VksLfr3i0GqWB6TbT2bHSWyy5McLVh0M44USzhCLtYWPVSduEIZWC4+K369KqzgMBLLnouRn0d2XYtotMm/UeaNmrVI4N8dTzywGLIFK49+te+e4aOm1R2K7hn8RDOn7gAxTWgddrnRiqEMEIDkU4ytauyx2SJy7a76JaSU51v5lDiiJeycV04fQAPVI+vWNgSEAlRIV1HoLvqjI3alRhdDd8bibwt/UyXzz69lhXZSOSV9vN4OOqFrz9tcyPQ/kwBgfEues1YxX1pt2nJRJBm7ewc2YmXX/lCvOhRV8HzBc7dvhvPfdRT0ZBNHKkeSQKb2Rj+nvVINWqWXtTcexbuwW1zt6BuYvh31GWNT2XasOx1TWPafl0/Jo6NwxOzxEJzLvk87U1uTwzazkEQ5KAZN3DP4l0d7bLPU6ywe2wbJktjmXLSqrqVbGz2PUqWJjcJQZqETl1JD5w9LeV1NhwGRAJbittQ8UbgGkJHJKOexvo8UKzwuVv/Faeqc0CKwiqEQNkdQclpBdC049wxKUXJvCOL9k1g1B/FvrE9fevEYMQywlKwmGrnEP4bOSjjG4FBNocLiOiFAMbb7A2vALB+I2eN0b44dWNQtFMm03/3GxCe8FHsErV1aI76KgZFuypEtfkB6O9zboxopRdlZrz8cVdBzmmVyet/9hW4cOoiFJ0ClNGhN+NmkhzJE75RMQE2vLelHqb723EcHK+fxHX33YjFxnJm00rasgKufUcb+viLtLc1X4HZexxyUItriR+EMuoMxSrZhAX0BqtTYcaYC+Y0s0spMCtIJRHEQWtjSS9qRgWRNni3+4Pk6QOwNv4DSJz4uvXLqtQdK9zIrbrngomLUHJHEKsIYUqtA/RXoaT7In2dAmOusQgJ1VEvnWeiS9tT49JmruPsy4YDByW3krFPdKsbmeRGuYg+qZ/2vgFRxzpkHRdtffsh79jvW78BTkRXAXgBgOcD+Hzqq2UAH2fm61b19DXCILZSWv/Y7bueoQb63NcPXQdNzgVurcI4d2OM9GOAdKtH+loiwiNe/Wx86z2fRdEvmPJ07t9YSSyHixBEGC9MQpCTqC20v4VqSWWky5MqRqRiCBL43zf9E7aPTeNZ5z8ejE6pbS3pfpa1lGEZpTeinM/S7Ur1saUxm0VD57KQJmGSg0hFYEj4opjo3XUKTELNGM9tGOsOimjKGL7SvrCbkit0bgKrVho2IVYvdGOIdb2uh5qwGTewHC1hurg58/4HMrtYIZ3VMVYRAhlAkI746ibqVkagWqly28u1/bsQzGPUH0MUxSj6hcSnw15rN45uHtLdfC/WCi3fnux76/ecPO+kH1spL5X10cx8/cALzxDOFiprO4ahn7aMdaujFq6WVhvJUCdVHxCYTSqJarSIhdoyto5tgUM63LmNP9SrPfW4hoVgFiW3Aoo8lEr6tNGUDVTc0Q6/gbVCLa7CF4U1oW5awcIu6Pq01No0jtbuw2RhWucXaJukihVijqCU9iVxjd0KjIxhNr14WSFmENV1pdTfjUSvuqWdxFYCGxAx/T4Xgzl4jo97lg7hwslLey/kaPWvXXg/ffcn8PTtz8JFr3gajn7yOwPr/WDHWkRlvZmIXktE7yWiD9nfNazjQxLDDCbtgLN6r8nVDmRXeBhELyUQIhViMVzAu/7xg/joV/4Rjomzkxiae7Sn7FawrbwLx6pH8dK/+FV86tv/F3cu3gafNB12sbmER7/rZatqQzeUnUoHdZOZE3vJSmCZR+0MpEA2UZdVbC1tT1KxdtwLbShtyiYasgFS+v6Yow51QqiC5Bnt9NdMO/qoYNLXrGW+717oKXT2+HhY3wEtiJBW6ZnC67KGxXABuyvnJO+122msVSXGyfoDiFSE5+59HkZKI7jz77/Rpepn3g6wkch7cvgUgNuh80a/FcBLAdzGzL++vtXLh7P15DAMmBmRyWB1JiSVtISUR1q6ff4OzDVncenkZajW69g6ualD1WLRIb0xYzlaRK1RR9EpQ/iMEW8MBMLx+v1oNgk7xjf1XGDXEmslUduTQ0ITRXeqqPYo12qlUAa45h/+FlccvBzPvvKnknv0xtCEJwodznRAl/5sUxtmTjas4JgczMDaqz3aEasYhE7WWDfVyGphnSuRhNFQmGvOYMybRDXWqqp+JxZbL8D4tIiWF3hy3SpP4mcr+p0c8oqo+5n5RUR0FTN/hIj+AcCX166K/wULIoK7SvriapFng5AqRqhCnDO2B0XHR9kvoVIoJ9endbW9UIuruHvpEEbcEUyXNiXqKBAwVdiMYrnUCqexzlirxTLt4zD4OpGol17+rJ9BGGZDhwSyCc9pJeJJv5NBZduTm4BAPa6hFlWxpbxtw1RKvfIur0e4ez3Wss8+Ur0Pkg9j39g+RDKE53T37rfjyyEHdy3egfPGDkDkXhZbiFXcNzR8HtgYVmttDxoWed+UPXMvENElAMYB7F2XGhkQ0TOJ6A4iOkQ6I9yGYSlc0MnRzxAE5c+4tdGwE97WsSAK2FHZkaiQ0gvToHJ8UcDO8i44wkHMMU43Tmk1ACNJEekI9yF7nCfoGD6+KGD71Bbs37E3871DbiZkOtB/Y9CGfpn0YStWUgkOiRV59q4WOi5R5/KyWpJFz+ehRQdmZuys7MGW0jYURFGH0LBlMOvwG+ESGlE9GccMxnRxkyYD9WH69KpDmjQwPAh52YQbgbybw/tJR2X9fWjW0q0ArlmvSpHOSvPXAJ4F4CIAP09EF63lM/oNAE156x8O+qGIROo3G9Op+kkEcRu9kBmRjHCydhoPLJ3WlFQbuC7F9klotKz9AtophAwtIU0XN2NbaQesydAe761u3IYLX6sNohnXIVWc1EUphXqsg6Hp9g0Xfr0bJbrvtfaHGbceuwezS0uZMB3MDFe4yUIPZPtAKZV4AtvfuomlZXOMxzLGUrgEMGOysAmqjf7ZXuaZQB5Bov36Qd8xGFtL27Crsjvx1ejwLSGBkEMQjKBDAlPFTRmpvb2vwK3PQhkkYcfZSPurPZVZYWijMGis5tocmPkDzDzPzP/GzOcy8xZmft+a1LA7fhLAIWa+h5lDAB8HcNVqCmznQ/cKGwAAI96o9nhewyN4nsUj7wJj8xisZAFrb3/XMlX2+XPBLGabp1uTznweqiYeqB3Fn173AYQqTBY1AJAy1gs7sikX7eJrF17tdKT16AWngIJTxJby9lYeXzMRm7KR7Z8hFrN0fwUqQNCW1lKHAbEqG02HrEbVFS34AJI2n6idzviItPd90n7jWX104Th+71Pvyixu9u+G7O4gmLQr1R/L0XISQjyUIUIZ4bb5HyOQbRFI7VqX8qlYSwwaa2mkhZGT1dmeG/PJpVmwGqxOsxGSiVqnMl+0op/qBdhBxa1gzBuH4Va3+qLfIwwNGwxDxQ6hkHX03CiBciV9PCwGOcH9Zr/fdasVsBPA/an/HzWfpev2aiK6kYhunJk5nbvgM6muaQ8xPOw1MUeZ8MkrQU+KI1jnyjVhMADgwsmLsXNkV2ZDBemwGhPFcZy7dRqnm6dwaPGOpIymakKqOIlhA0qpEsw/iUOWUatk8yPI5FlEhKZq6rKZM6fulUzCmCM04jqICOP+JMpuJamTEAK7R/Ym1woT/+lE/QSuP359XyEiXQe7GBERrj/+Pfz70e/q+lKrz9P+KzFHAOkQCc+57Em4dGov/u5fPpV41Frbxag3nrE52B9HOPAdvxWrh7QqznO0D8OdS7eiHjXxrus/i/nwNBajeSwEcxn1X7+2rQVWOtduPn4b/teNn+5apye85xU6BteAMjN+ItRdCEy3vcPXBa1x3v7u0vcVvTKKbhmCBGaDmY56bNSJbDXr2aB3P8gJ7up+NzPzHw1Xrf4gohcBeAYz/3fz/5cB+Elmfl236/Owlc4GtkEeRkzea4B8+ltb3qD2s/HAlIgh4GSMa+nnMTNijhHIBu5ZOIYP3voxPH3PY/Csvc/MlJ1+pi3bhimwDj0Ag8xCqFi1kq+YCR6pEL4oQLHSMfhlgMnipsx0zcuLH9SvaT8Ci0FhvpkVQhV0TfcolUx07rY9GfaLqY+llcYqQixjFN2iNlRDe1enfUT6sceYGdVoGRVvxKTtVGAAy+ESAhng0NKduGjyYoz5E2uSjnMQ8jDduiGWMdwuCXBiKeE6+Qy1DE5UkXnaak93BJ1TpOAUu97Xjb0EaBVfzBGasonvn74Jj932hETgWamP00o262H7OI2h2UrrtfjnwFEAu1P/3wXggdUUeDYYePO8+GGu6bfwqyRa6KCQ2FpP7cLTx+zUwEs/j8FYCGYx5k/g4OQ+/N5PvAGecLpea25oeena4UaatRJzjNgkZPGEj5gjuOQhVAF8pwCHHMyHpzHuTSGSEZqy0dLLY3DO4r591jYRiTrzLg9ijegon4Wu37Xf214/++xANtGIa6h4o/BcDxFHcOAkXr/WRyStcurW1lAFKAgfUsUg4eFE4xjK7ghixBAEXDx5GUpuqWvb1wPDzrduG4P+fGUMHgWFK//ypfj2G/5+oEOpjlCr4JCLklOCFTwkxwhk0JdKTUYt5VMBrvDwyM1XohdVrZtQ1+7cKFV+B9j1XtMGpQl9d7/vmfn1a1udBN8FcICI9gE4BuDnoH0s/gtdkDlKt2HQptAqQyd/78anz5YnUPHGUI+r8ISPTaUpfT21UmZmpC6zEQhqDXit32UsBguoxUvYVNyKAonUwq8S9VFJlE1I8kl4sacTCAk/kbjT9E7F3cOgdEOkAnii0LFBrBSrlcKLThE/mr0FFbeMg5MHITmEQy4+fMs/4GUXvBi+6/d9HxYEgiIJ17R/3J9qJbzhGA3ZwEIwh6nitKbICr9l33mIwdpz3v/iqzPjoZcgoZ0LrXDTyn4Xy9g42HWOq3QZln4tIFBySsnJpf0kGqgAwghCaRtIIpRwfwFgozHINH7ThtSiDcwcE9GvQftSOAA+xMy3nIm6PFjQazDlXfCIKAkP3c8uwcyYmZ/F//zYe/Dw/RfjNc99uV6YlMThpcOYKk5jqqg3jEiGeiKAMvFvCAQFxog7AiIYSdmwnFjBgWdOGxKu4+HQ3BHccfpePPv8x+nsdo6C3yaxN+MmPOFhOV7EqNdKpiKVRKhCuMKBJzTXvRHXTEIYzuRGzoOMbnoNJjCRwAWTBzHbmIOmBhcBEK7Y+rBkkUnrvvtBMScOXEWnlKiXJBMq5GKZFzHTOAnfKXb030MNRISH7Txou2/gtd1O40RCC1dsnPd6nCQzaluy3toEGHVVbHJDEBOaShMsYhWj5Ja0WpVaG5NSEguNGXzhun/F+dsO4DEXP7LjeRtx8gMGq5U+su416P3sLwH40pl6/mpxNtg41gIZKYb1YjtSLqPRCHD30fuhlDKnDaDkFtGM62DWocL1fXp6Jgud/gIEgu8U4Dqelq5Y5z5whY7NpA8j2io4VizjnoUjAHQYaWuLsJNSs39MFY19w1JrdRVYR0ElNmEo7GakTykrmWx6w/NsI4buU9s/UsWouGWMjo0mfQMGLpo62DVDW6+yrLzMdjOxhlaj1nOFh6JTwmK4AMkSk4WpFUmo1qZRdIsm4U2LZHC2jvF2lh2wgtMhA8KEfrGqn/ZxkpAkUvckr4PN2Er1saAWTZnBuOnUj3D5povgOa0kTI7Q9r4t01O498RRPPqiR3TduCzjbT03iVykWiLaDOC3oX0OklDdzPzknjf9Fx4ySA9wBYmJ0gTe/6a3wSEvUUMREbaUt2actlzhZSeP3Sus30Lq1MBKS1gOOxBEgAB86DhLU8UJvOoRL0g2lHZ1CIPhOwUwbPgNgJXdCASKXjYRUyGVfKjdzjAIMcdw4EKswN7RDwoKsYpQNLkG7KRPAskl+3L/hdwRDqCyG7ndDD3yTbgOhUA2UDEJj/LW20YKDlUIFSmM+KMD710JaWK9ICASenFio8orCBAQyhAlx82cqjOXtBE97DzwyE+eD7RUtawYnuNDCAcFuLj2yH/goqnzM+QPAYFxfxLPuvxpSb3thtNu+1tRe4ZA3pnxMQC3AdgH4I8A3AttF/gv9MBKJt/ZjHQ7iAi+ifMjyMHR2r2IVADLGtKJdJwMhbX9B9AhC5Zq1Va+AiPBl9wyHMfNbCgMnVkuLQXa04FdgCyFtOVvoSdqU9aT8nu2b4V0zrJb0Scdai3kKwWBkgkvyIEjvKTPLHc9Xa9+YymhtpKjcxFY/5KURG+ps0WnhG3lnRmddx6wUfFNFzdhvDCR9He/vl1vmmweWHoxoPtVmuB8dvz0g85UWMlQXru1p31+9GqzPUX7wodLesN59WU/j4LjI+Kwda8evsn/0+MhXTe78a1nH+fdHKaZ+YMAIuMI9yoAj1q3Wj3I8VD3rK7HNQQqwJ6Rc8EAAtVsRb9Me1P3MKQ65OIL11+Lqz/8juS69pAhraO4wJg3gRF3NNHfxhwh5tgke28lZlHmGC85BgjwRKFnHSyYGYFsDmxzezm2fqEK+7a1H2wQOs8Y6+0mayXC9HP61s1cWxBFcNuCYRfFY7UH8PVj/woGo+xWVlRPR7hrHixvI8Fg3F+9Dx+/6xNYChcwF8wgkE0Esjm0Y+UwSEc6FhAY9yahWGYiAre/b4da9O90Xa0wtK71zXmdrf1xInoONK101/pU6cxiLZgCS9Eixv2JNapRPmyUjYOIUDR6fwBwoKUgyRJKSZOCUmjaavoEYPS2VuJ56VNegLnlBVv5vhKQ9a8gmON9y5SRaa8NaS1Zwc1pZLanoW7o0DG3jQ1BAh68nt8Peq5VaWXablgukQpQEIO99BmmX1lAQcKBi1AFSUIba3vZO7oXW4tb4QsPYoW00I46Pp8syOIAACAASURBVMggSGDPyDl4wb4tKDpFNGRdn6REGQ1Zhyd0UqBeevz0OOilxglV0NfIb9VD7eSHarSEcT9r/+kYQ6Q9sjWnMG3AHv6d5BmreTeHPyaicQBvBPAeAGMAfmPomp3lWO0GEcjmmmwyK0E/Outaw6pCJOtQGT4VoHOoU0eWrTSPm5TxDIb2DJ4c1eG5JSSIsyqKbgOf0WLjEGljLkGA0LJ7aH292zrRxBHG/c5c2mn0mmRWBZFM6C7Ul9U4NXb7PGadHc+j/GwiqSRIIDG0V6MGPL8VhdQ+p+JXjLSMB/VJYBgIcjDij4CZUaYKFBRcciCcYjLufvcb74RyY1zz+Debd68glXbeZKUghINqvAyPfJM7vgWXBvsmxBwlwpR9ZsmpDKSPA3os2lOEPS2v9h0OemauzYGZv2D+XATwU6uq0X8CjPnjiGQEV7gb4o1qsZGbkYCO8hlxqNUiZBZ5dHotB7KJolNCUzXhGX1r2lhoJf6mbBjqq1Y9tRv7OiV3mxVNQ7I0TncxYpY6f/MQ4Zct0hsugVCNllByK10pjb36/nj9KDYVt8LvETK6HXbCCyG6trnrPcIBQObk4KDklhMvdFe42ftZe2M75HTNkPZQh7VDWANz+k3+7AVPR2DyWGubknYOJbiwmdBLTqmrvSLPPG/3uSDSqUytz83R5QdwrHocV27P0le1TclNxmPMUWJnSsPWa63WnLxspX0AXgdgb/oeZn7+mtRiA9FL/WInYaLvzTFnek3colPSERvR0r+v17F8o1kh9nnWAB3GIUKl/RmkiqFEKy6Q1ZMKCLBSYJYg4SXyijBZ44CWvj3zHKM+SuwK5v9JW6l1OpEmsJyCQlMFcCDgkIOiN5KrPe0qKgAZCQ/Qpx2Yd5q3vwsm/Ee/ezLMk0QyVLZSiUrC1snWW7KEIJHQibUhHvDIg1IKChLMTqZtrnA1k8nahejMOFyl+13/s351yHuKv2L7JV3uMf0NBSl1wiRHdLKFutoZU49UrHDr7O244Uc/xuMvfiT2Tu+BJzTbLzbRdcf9Mdwa3oHFcAECDka8VnrZ5HTBABQQUwyXsyrN5O8ca0Ke/sgrVn0OwAcB/JOu2kMPg1Qag+5pR5Ia00xMacJYdNNptmMYelo6htJGTHYiArGmllajJZRdwE1J+2y04SCg4BTBzCZ8MkGqqBUmwdoPoK+LVZwY7ZITAzMkYk0RpOxEALQkzMRw4ECwQCQDlPzJhFXTjmHVbzaMwkr6d6q4Wd+TY6KmF5l2DVY3rjsAQ09twneyebEz9MtUYUI4cFVrI14Ol/QilNJlb5STFbBxp92VzgsyG7OXqIvIhDZxO8pRrLI2MDumEz8bfd1isIR3f/lDGBsrYufkNp3tMUV9HfEreNqeJ2ExXMSp5gmMePsz78KuHZ7jI5a1TJsSL+4uQs6wyLs5NJm5byiNBws2ajC2Ty7FEsvRMqYK0yu+d9C17QNoPZEsIEaSVyoGQ2EuOI3NxW3wzAbBSiVHYF8UAQIEO1CQKLqllj7fhB6wCFQDJaeSWTCFEGDOXmfbymBU42UUnCIkYhRECRVvNFdWLgJ1SM79FpFh7DqDTgvdru9QP3S7zpy0iAghBxAs4JPfkhoFwWFXG6uNpzSl1Eg20OG9y3fjvLHz9cbHrafmOjqvAhtp4B52TqTrSKBWbCpjjxBG+GhEDQg4EA60Fz7rq2Bp2kZw2V/aj3NLe+EGfkvQ6NIPE4UJjPlj0Cy+7gmTym72ROxQ/+gGwyCvcupdRHQ1ET2aiB5hf9esFuuEjTLQ5oEn/Fwbw0qQprWdCVimz7g/hR3l3UlGt3pcw3w4i0jpjcEO8Gq8BGob7FZPattScUdbYajR0s06VnduXmk6kmbZLWMxnEctruGPb7wGGPDeM9z0LpMpj3EwD6zNYDXl9PMjsP06WZjWdgYwAtXIrOt20YhZohHr3BCOcOAIBwoKl049HEW3hBONY8nJc6Z5Cncu3pqrjQ819KKhhzLAYriQ/L8e15LQ83/9w7/B5PMuxd4XP06XAUagQlSjpVa5YPzuB96Om4NDePmfvwmnF+f7zlublyIv1kMozPv0SwH8MoA/BfAX5vfP17w26wAroa7HRrGRHOmedThDz08GI2m+kE14shwtgkCY9KdREMWMznTEG8twsxkm25sxJKcTpliHJXud/TdRM6k4SeLjiyKmC5vxiTs/jTc+/HX6pLLadq3ymjS6vaP1OuH51Gq79XEAAE94raxo6VMbNCFga3EHFCvceORGvOT3fxN7R89LFr+HOtIGZtVFa87MKDolFEQh8Y0ouyNJeJP3/MWn8O2/+wS+/f7PJKFbfOF3SPfv+8234bJ9OqHleuVGX8v1IO/m8NMAzmXmJzLzT5nfB03ojJijdVnIFcuObFz/2aD1oMLYWBhj3rhehKyHJ+uUigAyJ4LM/Ya5JFkiNMl9dDazZsciauPVOOTq/jeTzBUennXO01DxKqs+SfVauNfanrMWZSWnIHuiorY4QgxE0tCHU5JoK58GJacQAuGSnZfgtT/3i/irGz6+QQrYM4/rjn8TC4E+FbQ7ljXjBh6o349aXEXBKeLOhdvxqbs+iRO1EwD0xvHVt38M500dwJ9c92EQ6zze7adTAsFzPPzVi34b3/rLT+BkdD9+8lefN3SdmXUu7PVE3s3hBwA21qtrFYhkhFjFyUvJBApbQ7R79W400gPwTD1fkMB8MIf5YA4OuV2NwL0k57S9wabMtIZ8zRTKspdO12cw25gFAQhkIxO+gogwWezvz7AWWIkgQKmfPOUOI2ToXMYxYhW2+sMYQ60U222zbFdZSJaIVAhPuHjG5Y/H7onpDhXgQxUXTV2SUI3bnR59p4BRbxzfvPtm/N7X3o1T9WU8YssjUHJL+MyhL+IX/+I3sCROw3c8vOjiZ0IigiAdmTVSYeu0C0YjrmPLyDQu3HUAn7/nOtx+9B5DKAh6Va0v2t/hl27/D3z7vh8O3xHt5ee8biuA24noy0T0efu7ZrVYJZhbKh4Gm6ieLRppOobPStGI60nQsqVwscUmSZc95AKdzjP8YEbJKSM2Enx6QWEw7ly4wyRib7WTwZgP5rAUahWUdaY73ZxJaKva+cxJVEiBbKLoFhGzdnxzHc1cCmQTkmMopeAL7bnd3p/p/69FX6/HSTFWug1569diK+nTE0FoGyhS9Fe0NuFkrKGVvxspurFUMT75wy8jVhIg4OHb9yf+J/Z5DIZUMhPXqldfcNvP2Yyp4hTKbhkqlWtcKYlaWMViOI9Rbwye7+OehXux0FzE5tImjPmj2FKewoXn7ofLPiIV4ol7rkCsYjTiOhajBcQqStYOyyYSJCCEg4dvvhSVchlLtWXMN3XOcaliRLJz/HYFddoaD0zvQTWodawp7X8rJRHKIIly0At52UpX57zurAARwXHynRYG0fa02kKzN5aDRQR1CQJjamzSsGhWN/CHVVV857abcfl5F6HgrSyI2nqg5JZQ9sqtvuCWj8DJxglsK29L2qmUSuh2p5onMeKPakGXGZGKEBkqayu8hO77QDYx4o2i7Om4QA45EBAIOTAxinRua8lxX2/V1fTVep7SNBNKAWYhT5+ILNKcervgWkdAYVOwghNv87QfiWI54ARN+Oa938cLLn4qhGHXpNuc0IrBGV+TXuVp3wvjJ7DCbotklKSU3cixrceo8SFREoFqmBOxh4lKCT9x7kW4dPO5iFWESIW4bNOFuOL5l6NghBKQVodGKsJisIAtpe2Z8okIrvBAIDx1z5UY8cu4e+4IxsZcbOItIAhEKsqdCQ5tpLL907tx3nT3qEaZscP6pDgw+GCuOuhgex2/+VrQCSL6MyK6nYh+SET/SEQTqe/eQkSHiOgOInpG/kLtP/mP8uZ5fb+vuKNa9iKBHaO7sVBbxEvf9uut/MCrGLyWkTBMGe/43Adw6IF7h372WqI91otihVjFYFZ47LbHY8Q4oinzE8oAE4VJHBg/CMAs9EJgZ2U3Kl5FS6ysEjuEIxyM+5NwyG2FPwZDQaLgFpOEQoJE14ijZ3rzzANXuEmI817Sdrqf7WLtOX6S85iIMhM+Od0KbRPqau8xaiff8fHeq/4/VLwSCk4RO0f2dL3e5tvoR9E1FyeOiXnVahaSI4Qy3PD35ggdD4yZUVNVFN0S9ozuw3K0hNvmf4Cn7n0ktld2YqIwBQWFoltMgh1ah7aCW8K4P4m9Y+eh7JYRxEEyz2PWm0pTNnHX/N1QJHH19X+NAxMXmogACuW8NrMUa89CCJ1eNlRB3zJ0YiwfFbe/g2jfzYGIvmn+XSaipdTvMhEt9bt3AL4K4BJmvgzAnQDeYp5zEXRK0IsBPBPAe4nyBRCJVZQMwm4Ta1gJP62zJRAO7NyHL1/z0aHKWkv8zi+/Evt3dU7gswGe46Ep66jGy3DI0dKSMXo6JLLOWnbhYB1XSLFOyuMKTy9EqbABVn3ErBDETYQy0I5vpKVtRzgPyphBiepGx2tohbbo5ziXorKmx7sjTGBCc2uoAoQyMMH8uqsRGIyIteR7qnkcEvGqxpUmDDj5JeDUfQBQdMsdsYvWE+n+Y6UQsU4mVRRlxDLGtvJ2/OyBF+HA2PlgZjRlEwDBJdck5/E01doQABQUIqn7+r7qfbjp1I0m85uOo/Sdk9fhqr95E77x3o/iyQcP4mtH/0Xfq1rrV541zApPMmWYFiRwunEKS+Fi8lnG7kSMuxeO4PVfeFvCZOuFvpsDMz/O/DvKzGOp31FmHutbcv9yv8KccLm+jVaE16sAfJyZA2Y+DOAQgJ8cVB6RDnyVVmu0d+5iOP+g1+2ncfn0IxJq4tmIEXdMn7raGEsgyuS1tqe8SEVgVqjGSx3vKVaxicfUUp1cf/J63DhzA2pxFcyMH87evJHN64lhx1gkY0QqRKiaGem/HtdWprc3xuhQBokfiid8vVj3ULcxc+L5O+ZNmA2599IQxb0prkM7nJ1BYgXQolFLlgBxEvvrdHASpxonUBBFFN0yRr1xlN0KiqLUioIAyx5q9Ys9BR6cOIhLpy/Dj+d+iBO143DIxeO2PxE/estn8bc/+Aj+/E8+ilFPh6P/5o+/i195x1taZba989DGfYIRDkz+kvY88VtK23qGZScSuGTLQbz9GW8cGPI7l1qJiB5FRKOp/48Q0ZV57s2BVwH4Z/P3TgD3p747aj7rVqdXE9GNRHTjzMxpEGn99j1Lh7rq00b98W7FZPBg2TzYRAo9G08NFqeCE0kEViJK8jfb/6f/JqKEM152RhCohl4UzWRtxDWcqp+Agg70BwBXbn0U9o7uAxEh4hCzwexQ9VSs8K3jQ2tIO2B9N1aKt3/mfbj2B9+BS35moSw6pb4LZ/t3NgFMOmR3u9qvHUer9xo1nUpUVN1OYHZ+vPitr8XJuZncdcqLM7lBRCrEXYu3oRZXMdM4qccuM6YKmzFVmG7Rfc2/acowYD3b3cSelu7rmcZJbC5uxrg/bhw6HVx79Cv4tYe9Bh976zswHm/GI3/lOfjsf/wzXvczv9izjvadJkmLzDtLb0oMferudYK2dRstDFZf5WUr/Q2Aaur/dfNZTxDR14jox11+r0pd83sAYuhMc7runei6YjPz+5n5Cma+YvPmTQCATcXNOFWfwd2Ld2sKUwppiiVz9wmsN5X+R62zAVb90gua+bAx7egl1U76U3DJS+o5qO/ZSGuCBAqiCD+1mRScElzhohZXEUgtWb/rkx/GyeMLKJiQyw/fdMVQ9RcksN/YPtYCwyxwBMIrn/Ii7Nu6C/cs3YV6XMvUL0+5iYEaIhEe8mJzaRukitGMQlxz3Yf087osHG/72F/hR4fvwB+87NdRLpZzl3+2Q9tSPGwubUXBKeF/XPOHWA5r+Mitn+t54uomdbfbhOzPpuIWjPvj8BwvYZRdue1KbC5vwpXnXYHRwhhuu+8QfnT4DuzcvhmnG6cQpdTk6fLbnecUS9TjKhpxveW02IXJlJyKkH+M5mUrEafEamZWRP2znzPzU/sWSPSLAJ4L4Cmpso8C2J26bBd0YqG+sHcvh0uYLk5DqsEMoG4LWsLusGrwdkokVMcR7kxASwXck2llVS9rDR3qudOw2Q022F6gmtpox9w3raGVaBRL2PwMWp0ELEfLmG3OYXNxWmtNHMYF5+/BYrCEWMU4VT+JnZVdybtb6QK9tbxtRdf3w7CU6Z3TWwEAs83TkIYqqli2ghDm6HNpwpQrlkluh25hnK0PkCMcxCpG0SkikE0cXj6ETeVxRDKE5/gd7XjyIx6LOI7w8AOX4KGEf7n3m9hWGcOBifMgILB3z3b83T99Cnsu353MtXYkwg5alOG0yicZ7yAU3SIcKVrzks2YY6AoSpgaE/idn/9VVMoleOShoRpYDOYx4o6i5GU34bSNzhIwYifCfUv3Q0Fh//h5PW1vto55NQ55xYt7iOj1ROSZ318HcE/OezsrSfRMAL8N4PnMXE999XkAP0dEBSLaB+AAgBsGl6gXSoccNOI6Dk6eb8Ird7nSTrouTRckdGKPLuolfR8jkppJkeZED0KkIiw051GP6itWXWlOeZb/rn0requV7NE1U/814Jt3u7sXM0yZk4v1INeSS5SEbbCc/mRCgUAJE0lzvg8vHUEjroFZ4f7qUbjCRy2uYjlcwu49W3Fy6STmq/MIVYA4deJrb+egtq+VOnEYXn/GGArGVGEaJbeUSX9q69juK2JhJz0bPn3GwI2WP03relOCmQvSRBWdaZzEz170ZK226BJR4NEXPWLgxpDug3afiLMRzIwgbuKB6gmtNSDglc//WXz7lh/gGbsfC0/4ib9N+30Z/wGjTpxrzuFUbSYJwzHTmEE1rCY9aeeKnR8MhuMK/N7LXocXPek5uOvkvdqZVAg0ZOd64ZCbyQanc12PoOxWcPfCvajFVR0Ms+39JepF6i4Yd0PezeE1AB4D4Bi0dH8lgFfnvLcb/grAKICvEtH3ieh9AMDMtwD4JIBbAfwLgNcyD9bz2IaPFsZw6abLB+6MdVnr+33meJj62xUuQIxTzeNasuV8rA7FErct/Bg/mP3eUHaCSHU+Z6XlrIU3tQ0xnAfKsItc4SYDXCqZGaQy1X9aZ+skRj7JCn9ywwehmLEYzeNJO56IWtwAQeDQ0l2oRVV88Yav46Y7bsG5YwdQdIo9+fR52r6WC9hK+jl9rT092VDn7VVKn7zaT4eKpSYKm4U9KdOM2/R70zkJbHpX9f/aO/Mwycry0P/ec2rrbbpn3xlmRhYHRJgZEFEMWwRxGVFjSFBxuZer8Rpj1KghKpGHxGj0JsYVjXlcclG4BuUxGhWiICoMizAwMMAM2wwzw+wzvVTXcs57/zhLnVq7uquqq6r7+83TU1Vnfc853/mW93sXHM2TsJOcsXCDZ6Jp9zScCMjbVxnNj3T03JiIcP5xGzl/5cvpi3vxkl40/zS++4nPM9gzFJbXSu9fdJToui6u63Dvgc1cv/U7flm2OZYd5nd778L28594z9cbUUMk5DYOw6MjvOtzH+Znz97KQHyIeakFFTs6pd8FYfnAUi5edT4Wwlg+XXEEO2kz/05u1etlw8b1+pu775zWc+bcHHk3F4beNRSj6nIke4ihxHwUZW/6OVJ2CktshhLzAMLYMI7rkLATfmXlkHHGw2xmijKcOUrcjnP7s/fx5MhO3nnKZfTE+hqqvKZ2Tc3Pc1DpmFknQ8yKk3OzJOxk1esMVaBKmAvZ2z9Ln+9bMpGqLZ0fJWkXQlE32xT40cNbmZec31TVXTNRVUbyx+ix+4hZMfK+E1ql51LLYTWdHyXrZhjOHSMmcZb0Lg/3geL7n3Oz7B9/nkWppcSsGK7r4mgOEYt0fozN+zajKpy3/DxAfT8J77l4Dp921WNPtoz2xPruU9WKE3b1WiudKCK3icjD/u/TRORv6pZgBhK34qT8l2q6KVU5dBqBRUV/bDDsYS3uWcZQYj5z4gWrsSDnwh17bufZkWe9go0Q982SA7v8R3Y8yZWf/hBPbtvOnvv20mNXNtNrNS7NV5F4DoO58HtgbQIUWXiF27vFEURVFcdPD2qJTdpJ87nff6FIvVXLeCFp94QhR36+8yc8fuTRZl4eJw+tY2HPoqYes5nk3RzPDD9F2vHDmUemUrMV/EIq9dzBMxEdiA+xuGc5C5KLyTrZqtvGJM6S1HIWX7YBVeWxPU+w8X2v5s49t5O0U6weWM2i3vk4mi8zK46qwys1VHnNT+i/UC/1qpW+jueolgNQ1S14zmqzmnYNl3cce5yx/FhLGoiGw4H4+4876TC8yLHM4VANUhrMzcJi/aIzWJCaH1piBL2k/YcP8+Zr3svZ69bzqbd/kLdc8AauevWfTnnSN5RxivdtIrvwKR3T7xWqKnvHdjOaGylSZZRe522Pb+ZTP70e8BqKvJvn8PgBth3dSsbJ0GP38q51b2PXyNPeDlJb7sDsVUR4xdLzWTWwuqnXF3XW60QcdTh+YG3Y0StSI9e2uQEKZSlpJUPfA5cKlbMW5mNEBLGE+7/2n4zkhhkYSvHh//FO1i88ExDGnTQPH3iYXcO7QhVsQJl6q4rqqBnUa63Uq6qbSwRrbbxYQ1VW9B1XlOnMm+z1nKgSVtILAzBFgsnjqb7QLi6WWqFTYk6z9Mb7w7wNll3SGxaYEx9E/JzPQXj1vJtnwdAQV73mT3DUYcGCAcbdcVYtruj2MmkCFUF0aB704hN2suI+regMBA2A4zrMTy0IX+xSb/9g0vnla08nGUv4y5VDmf2k7F7WDLyAuOVFxV3Ys4inR7bXJXdhnkNDVdRswhYv8dHzY7tZ3LPMMzf18Z5LPnyfavqbFL0vUqae8yzJCkYXACsXLyPrjrPAWsRFJ51P3Irzo7t/yjduuZF5J/Zz/CUnsdYPLFRLpVV6Pc2i3hrggIisxTdYEZE3AXuaJoVhUvTEesN4QgFe/KfGC0ajvY4wkqcUftsSC8MKlOL6Dj0i4qlJouoQXC7a8DIsLHqsnjILrABnEpZjtWhmr2si9o3t5/59hfDKlljEJV40x1DpehKxOOe+4AzAm1jui/cTt2LErIIVi6sOOSc3ucnHaZ6/6RS8gIUWCTuBixP6CHnzAN4IIO8nliql0v0NLB5LR3222KG5X5BzOu/miImXhGlh7yIssTlp1Wrybo7bfrGZJ5/ZWXVCuppVXKXJ86lSbxfzvcD1wMki8hzwFHBFUyRoElH/BJhdhT209KEJjUODKhvx48sEFVXQo7LEQlTC4XVYgNXzH/G8g8TTr4qLhY3rh/IWEXri/aToK5twC3rQk5KxyvWJeMnbw2PXObkXtW+vl5Sd4smjT3P6wlPD3ns0jFj44isFvxs0dHJz3LznMGinsLDJu1mv0nHh+bG92GIXTV4aKmOJ5Vt5ReaT/El+7z8LfJ8FS61wlFXNlyhYFzp/BiMzUW5/8G6OuGOsW7WKHTt2svy4+Ygd5+ChYXIjGXDhWPYYp5/0Qn675QGe3r4b9yWFnByO64SBJ6NlotCZCDpfUtMIod5yXbNxEJG/jPz8CfBL724xCrwR+PyEZ5gGNPplCk5QM4lq4Z4DMk4m9D5u1ZxJ3s1h+SG1gx6OJRYJy1fXaKGA2lYMP94cNoW8uQ4OY844CSuF6zphDulKMkfDVQdORoEjUnCdYY/LLbwYE11/JUcnqK8xqGRJEmUg0c8bX/DaiscotZ8XlTBcQ+BY5eBwLHuUwcRcBG9i2cVlLDfCPfvv5eVLX9aSOZIoQVnrZFPVifC6IxYZJ0PaSRdCTwjYxFB1Q5+paMNQi6ARD+6P67rErBg33PYjbtj6C971uku55eb/ZtObzmXUyvGjO+7j2IPlihjLLqn8gzmLEtVj9Lyq+KHSa5fBehqIiUYOQTylk4AzgR/htVlvBe6YYN/pZZY2CqUP2VWXdH6EgUTlxH27Rp9hVf+aojmLZjOSH8YSi4H4IFHzyKLRXeQzhg1SGFUApJ1R+mL9PDf2LEt7V1SdA6n0zAv3Q/0kK5H5GT9nQr1hKSpt4+IW9cijjUi1F7e6jOW4uOHIK50fKwRRi5TxpJ3iQHo/aWec5b0rvHUq7Bx9mpu2/YY3rn1Ty9+HnJvt6OCP9SIizEvO5/nxPcQsm/74nLDHmdc8mXya/iA2W2QkV2leKHpMG5uMM86RzEF6Yv2MZTLkd4/wta/eCMBXv3RzTbl6k555bXB827LDOZDK5d5CpNgHpvb7UZuJQmD8rX+wnwPrVXXY/30NcFNdZ5gGZl+TUMBRp8iqImbF6I9XDzK4ZuAEoHJvuFk9wIH4IKM5L6J7tPcaTvhaSVx1Q0errJv1ckLjzT/EiBOTGJZls6Lv+LrPWzrUF/HiVkbXNWNeplaPvN6Jw3qOr6r02NX9aJb3ryyEaVAhrzmeHd7Jv7/qcw2dv17CkeAMoCfWx7aDj7Fg+SIc1+Fw9gC/3ftbTho8maeHn+Hi4y4Je+6ByXVAoPoM1u9L72XnyDOcMu9FxCTO3NQCbLHJ5mpnXosSs23idqyoPANYNVTH1VRdU6XecedxQPTKssDxTZOiCczGUQPAMyM7ypbVtE6pYiJZGt2xEcadtJ8kqVjl4EX79BqyQHeuqow5o+TVm5yL4YU6TlophjNHvFhLk2i0ykz7IvsWdPuNlZVWqVGi6ioRIet6Yc4zjpftrmhUEqrHxddxe+vPW3YhMWt6cpt3szqpFFtsPvmZr3LFjX/Nocx+5ibm89LFL2Np7zLmpwY5OH4AKFTA406aw5mD5DTHuJMG9QwjMk6aoeRcVvQdR9LqCR05vcCfkRMOlvuwRHn7a97Aq1/+B96PSH3/2NGtNZ9ttIw03kmpj+8Am0XkGhH5JHA38K2GzmxoCst6V068URWihcfrYzdHR/3Bm/6Jrfsew/FHAgF7xvbxox0/Dy2UvvGTwWSiKgAAHsVJREFUG/jJPb+kL9YfBvSzLC9wnFgWqXivlzK0Sxr+Rl/InJstStwStxKevwjixdeKjEpcdTyrGlzS+TGyTgYLa0aoedqBiPD+d7yFay74s9CUeU5iDntHD/D4wT30+R75gS9DwkrSE+/FFjv0cfBCZsQ5kjnMnrHdpJ1RjuQOk86lPWOLWKTXP1K7I5aMJ1kwOB/wrfzUK1+rBtZM6fqqWTfVot40odcB7wAOA0eAd6jq309aQkPTaVb4Dm9yuH6VS6XCtuPodg6PH2I4P8rOo7sZz6chCBiHsrBnHgt65oX7/+GGc0nF42EModCTVyHrjPtBzxpvsEZzw4zmRibesM1480DFIy3Hdfn8b77NvvRe9qX38sThbTxy6GFG8sMcyR4inRsjYSV8r+r6RkVBwvtGmUqF02lEr+HZ7GGSiSAxlZdcyhKXfel9gIbZ3YJ3JekbS4gfzTlwnOuJ9dIT68HCJmV5Mb8ePvAQo06kDDrV79t5p5/NK059CTGxi56T4zr02L00arJdL3XPSqrq/cD9LZSlaUxkKdLy85eE7g2+V9wWxXXdUNXTDUP1MmsaX+a+WB/DuWFe+6Jzmds75IeDKFR3tticu/wsBCGdH2XpgoWsWLgkzL4V1jMiqKtFk3+NELPipPPpSc+rNLMcVZuLiC63fCuZ6LJULEU6l2E8N04qnkJFOZY5yhJ3CXGJkdc8PdJbV/KnMjPgyO9WxI0qpZYlXTPmaqpRz7Fd12VF/woePvAomx/YwqaXXszc1DzmJOfwgrmrcP0wJbHIffKOKcXlVCAmNv2xfmJWnId2bOOIe5QF84d4xekb+f2WrRwcPlJTlsXzFnDxxvPCzlpBdq15LRVNazXi1CrFyye63Z3r194A09Uo1ON4VY+Ou5JzWCdTFN4hcm1L+payuHcJl73oAs5YdkpRwp5Syw5HHfaln/cjVVrknajDvZIoibI62d5SdPuknWIoOXdKld9ky1LV3rQWystEve1S56mPn/9ulg0sZ1HPEtbOOZGNi17C3OR8BhJDDCaGQqeregkS3hfNx9Qyy61y7yerRpvouls5Cql27OAaRIS3vfh15DXPv/y/77J75DkUl4WpRVx83IX0xvpIxorLpOcXE8eyrKIGw8Jmz9gedh/YwwPbH+XD3/p7DmeOcunpr+RtF7+JOfMGKsoCsHBoHjHfqTHIJV44n1XzHlXrfDhBvKUghEfwPCe43SYqawfQyl7TdHLw2GH6elMEfg2Cl992IrNZRx1G8yP0WD1FTmgzicCqKBpRc7IVa9CwNBpO21AdVSXtjNET621w/ijHjzf/jPd89pOkFg/wkSvezdZHt7HpzD/kjtF7+Lev3MCRg0dx3OKO4SVnvYLvf/JLhfdAi02ba44cqoz+xvIjZJwMQ8l54bLgGLWisrbO2L0NtKqSLX2xW8FMaCD+4YavcNqJJ3LpOecx4EdkrWfOwBabfnsAFZ0W9UYjTEW+YB9Li+/FZJ954H3eaqaaUW8mICI1zYfrQVWJW3Fe/5JX87qbXgV4/hLH1h8mafew+Egv7/jipfTHB3j08Db+8gdf4pGfbEGAZDxViMYbCTkTeGjXeiRBB6L0neux+/j0Pf/EJ17ykYIpdx3Pt61qJRH5kIioiCyILPuYiGwXkcdE5OLJHnMqQ9MJh/m+hUInoqrcs/937RYDVeVT7/xLXnXmBZ5JrGjZsDi6bVkWLdyuqIpyWr+tekAQWrvUrLZein03GjdRnIite3Zw5bf+puWTzZ06od34PfbCmwTWd5ZlcTR7mIQkGMuPctW1n+CL936bM991Gat6VnPswf186ZprOPOSs/jA294alpOgYQhkcTRfs3NQTc0nInxw/Z9zcHw/o7lh9qX3hJnoatG2kYOIrAT+EHg2smwdXijwU4BlwK0icmI92eAaZaJeXCt7s40URBHh5MF1TZRmaihKPBZnjt3PvfseYe2gl1gdyq/vd7seZO/ofl5/0oVh4xGoSsrjJnVWDzaINjspHX+VjkW91xXY1k/XfThl6Vrec+6ba24zpRHUDBgd14eEMcWCZzcvOZ8dx7bzhdtv5M1veiWrli/jp6fez7s/83H+7QOfZcnKOaxesJpTlq0L9wvCzwSVvk5w70SEnJMLg/9B4Tn1xJLYFiStnjBfyES0U630f4C/wgvJEbAJ+J6qZoCnRGQ7cBZQV9d4dhS8cgYS1T2ipwtB2Du2h4QdZ35qfsVENQGnLFpDds948f7T0CNuBlMxrW1Gx2I6742I8NI1L665jatu2Oi1ywKsUykty4IQs+Ks6FvJW854HfP6+xlK9fOFP17CwWcP8tJ1G9g//jxnH7+KnlhP9ePUcZ9tyw6TRgkSqqMUJSYxMm6a3lh/XQYebWkcROR1wHOq+mDJBS8H7or83uUvq3SMq/DzWK88buqOYDCzC+p0krJTZJw085Lz6bF7ChZK0YIo0J/o45yVZxT1iKuZ1s3GZ1OkRpouy7spVdqN2RrPtmfbF+/n7JWnh2X+wrWLYY2XcS5pp0jZKVSVfWP7iFsx5qbmhZPQjuvgquNZ91FQO0WtrYDQGQ98SyU3D37I/GeGn2Vx72Kgvk5OyxoHEbkVqJQ49mrgr4FXVtqtwrKKTZyqXo8XRpwNG9d3nuJyFjKYHOJY1ot/HyYcitYffnRtSywsOxE2DoqW2fcT7jKzVRHtvL7AgQuYdB0/WYdJg4eIhE6Iw5ljHD4yQk9/nIyTYTAxhOBF3N1xZDsvXXJOuJ/6ccmCSALh8kj5iar6Ap+SvOa91KGuw8OHHmb1nDWF7Sd4Li2bZVXVi1T11NI/4ElgNfCgiDwNrADuF5EleCOF6DBgBbC7VTIamkcwBB7OHuPp4R2k82NeheOXYyl8KfpdOvwuOmaVCbZWM53m3RUnECP/WomXXCnigNmi80mFf7OZINfGr3b+Nxve/Wq2HHyQ/3XT34W+J8v6lnHO0pcV+U7E7QS98f5CIiHfEtCL2VTuWBgN7/3c6LPc9fydbFq9qeBYV4cad9rVSqr6EBBmHPcbiI2qekBEbgH+r4h8Hm9C+gRg88TH9D9neC+zk1FVck6OVCzFyUOn0BcfKFIXBWZ2rroV/R467bkFUWOnSjeUxXonJg2NEZSlUIWKkrATvPUDH+cHX/k8/3Tnf/Dpy64i7+YnHUq/WjkLJrMzbobFvUt5weDJhZG6apgjpRYdZZ+pqluBG4FHgP8C3luvpVLO9UwMizwADdOG+jqjhCSLejBZN+P1Xo7uY9O/vp+cZouGs8H3TlM9NKNi77RrMtRHs01sM844GWc8PHbA9u/ezls/8DGeuu0JThw8adJ+VLWc4dLOGIcyB7h5+w9JWj3F+0nBmqrm8WdCRbp+w3q98+47Cvo2P1ZRM4K2GepDVXHUYSw/SsJOEBMvo1bgPKgov9+1jRcvOyHM3AbtmXydDiaa4J0NVjvdTDNHfoETbWl9pK5y3xMPknbSvPyFLykyf20ERx1c10EFRrMjDCaHULzsdHn1szT65+qN9c9sD2mR4tl3a4IYJIbmIyK4rhM2DCISuv0HYR/OWHFy9f1nWCXZ7Osxjcn00sz7HGSFK1tuCetPOC2ssButs7JOhpybA5Sj2aPMTy5gKDW3oN6FSYXAnxGNQymTsZmfSnJ4QzFBobatGOInQQ9srKOB5gQpDqZX8jI0YxShqmHioE59pko0Au3k953KvfECr3mZ8Oq9L8GzC0wlwwiflhmRNwvLskjQeEa9gnrWRbBIWIkwD0RgGCJUbqSqytawVIZZT1BZWWIVTXKG6S5xp3Ukl2tSRruA+x57iLHMeHPnsmRyHZJGLX0EIV9HyIRSykJ3RNJhmtF5Z+G9fwmSdpLB5FBRGteplJtZ3zg0I22kwS98fkjgMHa8eEPnoLdazWQyatbaqKmjiNAb62vqM/3aj/+d2+6/s2nHbIc5pyUWyVhycg2S71BVd2hv01hMmmhZaKhcqGd9lrJT2FaMmBWvGcq9nmc16xsHQ+MEJqqOOmSccS/oWMk/jWS06rZJaMuy6E81J+PeTKBWI24aiPagaJg1rt5GZqJnNSPnHAzTi6N5xp00MSuOqw4uGmo2PSumPLYUF7WoCWu0IHdiyO4v/fm1ZXH3p4tumogO7OgDusHXY6Yw2XDupc+qEqZxMDSMLTF67D5PlaTBh4YT0Dax2uqIqNu/HyiskxoI27ax7anl8mi0gqznJe4kaoU/mc15IqaFKiFoqm9eezujVjI0TJBwHfVCA7i+mins9ZZU9KXD3rv23s2BsQNA9fDW3UyjlftMqUzzmg8toLqpwes2mnVvZ96b2MUE1jD15KbuRII4PdsOP8pw9lh4HUGgsWrXtLh3EVnNhiOIqpNowdyG64T61eLzt7bSmcozcdUzJ+zG59ko0U5AUY82Eu5mNt6XRpjORtU0Dh1AEI53PJ/mcPoQ23ZuDyvAMCl9pMHIu/male104qjD0cxRRrLDjOVGyeTHybpZhnPHyvTPZfiV5pKeJcz389tGG0hHnYpZ44L10W1Lj1m6TTOYVN6CLm3gW4lt2b6Dqou6hdFlt96nXSO7yDm5poyGJrNvpW3DhtiPfNyMRsQ0Dh2Aqw6OOuwff56tB7fwmo+9E9uyyLmZ0K7cVSesnLRDGgbwKsEj2YM8emQrh7OHOJQ9yAlDL2Bhz0KEQujgIOJklGCU0JvoJRlLRa7PuzZH817M+pJY9bZlF5npRR208q53L6PHbwfBue2IGW+7aacqJzqKyGvekydIStMB92YqPHpoGwfGDzblWHWrDv3Kv+pxIibjDcvUKZVMI2zYuF5/c/ed7RbDUIHh3FH643PCidUiy6SCfqEpFUTGyfLHN3+Q72y6jtt23srr17yh4WPOJLrJ8slQTmCuOtkAfbXoifVVja1kRg6GluKqy6HMfvK+13JULRTgaOU5hMmSsOPc8Pp/pD8+wKWrXlO2vh0doU6aeDWNQvcznc/QmLIaWspAfI4Xj8cP+BX1b1DXi9PTrJ6Q4CVSB4jb5bkKMs44thUjPs15DDrJ3r9T5DBMjelUwZnGwdBSLLGLgstFQwWENu8tKO+VKsGEneyonrzBMBmmPeTKtJ4tgoi8T0QeE5GtIvKZyPKPich2f93F7ZLP0HyiFh315ttopnlqkFYxeuxW0444SgZDM2jLyEFEzgc2AaepakZEFvnL1wGXA6fgpQm9VUROrDcbnKHDiaZzrdNjurBrc5OvTGTR0er4T80OFd+JYUcM3U27Rg7vAT6tqhkAVd3nL98EfE9VM6r6FLAdOKtNMhqajIjUHao6rDxrBHmrum9kXqPSusC2PpproqrMLer1N9u81TQMhmbTrsbhROBcEblbRG4XkTP95cuBnZHtdvnLDDOEeirbahWnV6G7HBk5VnXf6Aij2rkC/4lacX6MOsgw22mZWklEbgWWVFh1tX/eucDZwJnAjSKyhspTkxW7diJyFXAVwMrjVjZDZEObiKpEaqlHFCXnZvnMjV/m1FUv5E8v3FR1u1oVuy0xU/EbDBPQssZBVS+qtk5E3gP8h3q6g80i4gIL8EYK0Zp+BbC7yvGvB64HzwmuWXIbWkOQZD2YEC71c7DwPKizboa4JHDx0o0O54YZTAwBXm8+Lgk+fsVfMDaernieiaKYBikvDYbppJPMmeulXWqlHwIXAIjIiUACOADcAlwuIkkRWQ2cAGxuk4yGJiIiRRFXXXV47Mgj7Dj2OMeyR8i52aJJWltsLLHpsXuLj2FZ9CRTzB+cW/1cXfYSGmYH3WZG3S4/h28C3xSRh4EscKU/itgqIjcCjwB54L3GUqn7qRRt1RKLJb3LGc0Nk4r1+NFWI0mB/G0TdqIdIhsMTUW1kN+kW2hL46CqWeAtVdZdB1w3vRIZWo2qsv/oIZ7bv4dT15yEbdkMJgYZTAx6MWNcB1cUuw7fh27EcZ2KwQfbSbebvzZL/lbHnCry1WlSHLGJzteMa5mZb6KhI8k7eT70tevIuTlctzAgFCQMa9HMqJLtJlopOH4k0k6jVrypTsuN0crjFB0z8q8px1NFdPrKdLPOY8JnGBqmKBVkhV5L0FNaNn8xt/3jDYA3CZ3X/LTHOZpOovchYSfbKEllJurBTraSqfTsq/Vim9F7buQY9Zg8N6uSddUh62RI2j1heHlLrIZGPuolbWjpKMSMHAxNoTSxT6Xoq1FssYmJ6Zt0M2XPtkqSmU6diK0mV7N7+DErzr70Pg6MP89w9ghHs4dw1WUkX91fpx4UDXOXtIIZ0TjMhJwUXU2V26+qrL3i3Kq7dbO+u146rWJspjw5zZYcT4vUhd1E6X1pdgNx3MDxzEsuZCA+xJz4XAShLzYw5eMFJtkWVsvK2IzounnJkbrPjnimEB3iRtVLec1x4ye/TN7NE7NmRFGbEp1WNpslT0xKVYKClBgUTHSeIL/4dJePSnK18jlZYmHZk7s3EyEIKq3rfMyIkUPnvHazk4o6ZTxfhQ0nvqijKsbZzg+3/JK7n36oKceyxCp6tnVH2lXFcT09vCkbjdHKMC8zo3GYgnVLpQTwzbZSaBfTLX+1SsHy8yfbVvPSGnYC0YTyQepGt0pe71ovbzvK2fHzlrH76D7cNqtig+CHQFPTXk4VE0urnFk71p/p+u5OUWXk3Ty230h0O0EqU0E8XWbkkoL7HW0g6oo+W7JfkRVNtRhTDVi5nLHiZM5YcfKU9m0WIkJMYsSsWNd3xDqZonvrfxWpHV4myowYOTSLqYSH7kQ66RqO5g7NiIYBwHHzOK7nrxCMVgUJkwgFL95E+SoCos8p8O+oZ/9m5NvuFDqprM4kijopCC5uWZma6L6bxqEL6abe1khuuN0i1M1E9zVmxQvhPapQqoefLLafa7sWaWeUfem9Uz6HoXE6/R3Mu7niBkK9oJZQ/0T4rFUrdTsTqY06JTTCir7j2y3CpKh1X+tN0NPofZ9o/77YQFFAQkN76BTVbSWCsPSBfC4OcSnEKatHbjNymEGoFpxignhF7aYTJhtnGt4kv+nXGaqjuEQdkGyJTbrTYkpYF1Kr1Y+GBNDO7NR0LJ3aCzR0Hp1SVqo571liE20cpjKanXWNQycPBRslatI7U4LXtYpo7giDoZtQ1YKlXGkEE9GIZZJVtp+jTpHxRC1mpFqpkg9DlMAm3YTd6C7M8zLMdgIHQtd10cC0WoSwRZggGN9kogPPyMZhoonDaqZdhs6mmc+r3sllg6HTGHNHyGmGjDMeRnl1URzNh2W6UtkWEZJ2qrBNJ5qyisjpInKXiDwgIveKyFmRdR8Tke0i8piIXNz0c/sBq8xEqcFg6DZEhDnxIVJ2LyA8dPD34bpmGym0a+TwGeBvVfV04BP+b0RkHXA5cApwCfBlEVOLGwyG2U0lx8eeWC8nD51alp+9WbSrcVBgjv99ENjtf98EfE9VM6r6FLAdOKvC/gaDwTBr+PWeXzGeHy9bHre9yLitMEBpl7XSXwA/E5F/xGugzvGXLwfuimy3y19WhohcBVwFsPK4la2T1GAwGNrMqfNOm3ZVeMsaBxG5FVhSYdXVwIXAB1T1ByLyZuBfgYuoHH27oomKql4PXA+wYeN6Y8YyQ2mFp/dMNmc2zEzmpxZM+zlb1jio6kXV1onIt4H3+z9vAr7hf98FRIcBKyionAyzlGY3EKZhMBgmpl1zDruBP/C/XwA84X+/BbhcRJIisho4AdjcBvkMHYIxOTUY2kO75hz+J/DPIhIDxvHnDlR1q4jcCDwC5IH3qrYwg7bBYDAYKtKWxkFV7wQ2VFl3HXDd9EpUHcfNk3bS9MenngzcYDAYuo0ZEVtJsHynkBZgQ198zsTbGQwGwwxiRobPMBgMBkNjmMbBYDAYDGWYxsFgMBgMZZjGwWAwGAxlmMbBYDAYDGXITEigIiL7gWem8ZQLgAPTeL5m0q2yd6vc0L2yd6vc0L2yT7fcq1R1YaUVM6JxmG5E5F5V3dhuOaZCt8rerXJD98rerXJD98reSXIbtZLBYDAYyjCNg8FgMBjKMI3D1Li+3QI0QLfK3q1yQ/fK3q1yQ/fK3jFymzkHg8FgMJRhRg4Gg8FgKMM0DgaDwWAowzQOEyAifyQiW0XEFZGNkeXHi0haRB7w/74aWbdBRB4Ske0i8gVpQ7aaanL76z7my/aYiFzcSXKXIiLXiMhzkft8aWRdxevoFETkEl+27SLy0XbLMxEi8rT//B8QkXv9ZfNE5Bci8oT/ObcD5PymiOwTkYcjy6rK2UnlpIrsnVnGVdX81fgDXgicBPwK2BhZfjzwcJV9NgMvxcuJ/VPgVR0k9zrgQSAJrAZ2AHanyF3hOq4BPlRhedXr6IQ/wPZlWgMkfFnXtVuuCWR+GlhQsuwzwEf97x8F/qED5HwFsD76/lWTs9PKSRXZO7KMm5HDBKjqo6r6WL3bi8hSYI6q/k69J/xt4PUtE7AKNeTeBHxPVTOq+hSwHTirU+SeBBWvo80yRTkL2K6qT6pqFvgenszdxibgW/73b9EBZUJV7wAOlSyuJmdHlZMqslejrbKbxqExVovI70XkdhE511+2HNgV2WaXv6xTWA7sjPwO5Otkuf+3iGzxh+SBuqDadXQKnS5fJRT4uYjcJyJX+csWq+oeAP9zUdukq001ObvlOXRcGZ8RmeAaRURuBZZUWHW1qv6oym57gONU9aCIbAB+KCKn4KlkSmmJvfAU5a4m37TJXUqt6wC+Alzry3It8DngnbRR3jrpdPkq8TJV3S0ii4BfiMi2dgvUBLrhOXRkGTeNA6CqF01hnwyQ8b/fJyI7gBPxWvcVkU1XALubIWcFGSYtN558KyO/A/mmTe5S6r0OEfk68GP/Z7Xr6BQ6Xb4yVHW3/7lPRG7GU2E8LyJLVXWPr3rc11Yhq1NNzo5/Dqr6fPC9k8q4UStNERFZKCK2/30NcALwpD+kHRaRs31rn7cB1Xrx7eAW4HIRSYrIajy5N3eq3P6LHnAZEFh5VLyO6ZavBvcAJ4jIahFJAJfjydyRiEifiAwE34FX4t3rW4Ar/c2upAPKRBWqydnp5aRzy3i7Zu275c9/WLvwRgnPAz/zl78R2IpnTXA/8NrIPhv9B7wD+CK+J3onyO2vu9qX7TEiFkmdIHeF6/gO8BCwBe9lWTrRdXTKH3Ap8Lgv49XtlmcCWdf4ZflBv1xf7S+fD9wGPOF/zusAWW/AU+vm/DL+rlpydlI5qSJ7R5ZxEz7DYDAYDGUYtZLBYDAYyjCNg8FgMBjKMI2DwWAwGMowjYPBYDAYyjCNg8FgMBjKMI2DYUbgR7b80BT2+22Tzv92EfliI7LUcY6fiMiQ//dnU9j/PBH58cRbGgymcTDMclT1nHbLUC+qeqmqHgGGgEk3DgbDZDCNg6FrEZGr/Tj3t+KFJ0dE1orIf/nB434tIif7yxeLyM0i8qD/d46/fMT/PM8PoHijiDwuIp8WkStEZLOf42Ctv91rReRuP+DirSKyeAIZTxeRu/ygajcHQdVE5Fci8g/+8R8PAjeKSK8vwxYR+b5/ro3+uqdFZAHwaWCtH/v/s6UjAhH5ooi83f9+iYhsE5E7gTdEtunzg7zd419LN0aMNbQQ0zgYuhI/2OHlwBl4ld6Z/qrrgfep6gbgQ8CX/eVfAG5X1RfjxdPfWuGwLwbeD7wIeCtwoqqeBXwDeJ+/zZ3A2ap6Bl4Y7r+aQNRvAx9R1dPwvGA/GVkX84//F5HlfwYc9re/FthQ4ZgfBXao6umq+uFqJxaRFPB14LXAuRQHN7wa+G9VPRM4H/isHzbDYABM4D1D93IucLOqjgGIyC1ACjgHuEkKSeyS/ucFePGiUFUHOFrhmPeoH/bZD6T4c3/5Q3gVKHjBz77vx8NJAE9VE1BEBoEhVb3dX/Qt4KbIJv/hf96HlzwK4OXAP/tyPiwiW6odvw5OBp5S1Sd8eb4LBKG4Xwm8LjI3kgKOAx5t4HyGGYRpHAzdTGnsFws4oqqnT/F4mch3N/LbpfCu/AvweVW9RUTOw8viNVWC4zuR408lNWueYi1AKvK9WnwcAd6ok0hkZZhdGLWSoVu5A7hMRHr8aKKvBcaAp0TkjwDE48X+9rcB7/GX2yIyZ4rnHQSe879fWWtDVT0KHJZCIqi3ArfX2AU8tdWbfTnX4am4ShkGBiK/nwHW+dE7B4EL/eXb8BJSrfV//0lkn58B7/Mj8CIiZ0wgl2GWYRoHQ1eiqvcD3wceAH4A/NpfdQXwLhEJoosGE63vB84XkYfw1DinTPHU1+CprX4NHKhj+yvx9PlbgNOBT02w/ZeBhf72H8GL1FmkAlPVg8BvRORhEfmsqu4EbvS3/Xfg9/5243hqpP/0J6SfiRzmWiAObBEv2f21dVyLYRZhorIaDB2EeDlC4qo67vf4b8ObGM+2WTTDLMPMORgMnUUv8EsRiePNC7zHNAyGdmBGDgaDwWAow8w5GAwGg6EM0zgYDAaDoQzTOBgMBoOhDNM4GAwGg6EM0zgYDAaDoYz/D4lKL6U/plCHAAAAAElFTkSuQmCC\n"
+          },
+          "metadata": {
+            "needs_background": "light"
+          }
+        }
+      ],
+      "execution_count": 5,
+      "metadata": {
+        "collapsed": true,
+        "jupyter": {
+          "source_hidden": false,
+          "outputs_hidden": false
+        },
+        "nteract": {
+          "transient": {
+            "deleting": false
+          }
+        },
+        "gather": {
+          "logged": 1618319325736
+        }
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Another plot shows the month of observation or collection."
+      ],
+      "metadata": {
+        "nteract": {
+          "transient": {
+            "deleting": false
+          }
+        }
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "some_plants = df[(df.kingdom == 'Plantae')]\n",
+        "ax = some_plants['month'].plot.hist(x='Month', y='Count', bins=12)\n",
+        "\n",
+        "ax.set_xlim(1, 12)"
+      ],
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "execution_count": 6,
+          "data": {
+            "text/plain": "(1.0, 12.0)"
+          },
+          "metadata": {}
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": "<Figure size 432x288 with 1 Axes>",
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAZgAAAD4CAYAAADRuPC7AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjEsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+j8jraAAAVPUlEQVR4nO3df/BddX3n8efLxCKoESmBxYRucJtqgdFVIkvrTtdKHVOhhO3WThwt2ZZttiyt2u1MTdqdxX/SwWnXH0xXWlYsQSkQ0Up2ldYY29qdQegXdOSXlExB+EpK0qpAtYUG3/vH/WR7Sb755n5DPvfm+83zMXPnnvu+53PP+0wyeeVzzrnnpqqQJOlwe96kG5AkLUwGjCSpCwNGktSFASNJ6sKAkSR1sXjSDYzbiSeeWCtWrJh0G5I0r9xxxx1/W1VL5zLmqAuYFStWMDU1Nek2JGleSfL1uY7xEJkkqQsDRpLUhQEjSerCgJEkdWHASJK6MGAkSV0YMJKkLgwYSVIXBowkqYuj7pv80lys2PCZsW3rocvPG9u2pHFwBiNJ6sKAkSR1YcBIkrowYCRJXRgwkqQuDBhJUhcGjCSpCwNGktSFASNJ6sKAkSR1YcBIkrowYCRJXRgwkqQuDBhJUhcGjCSpCwNGktRFt4BJ8tEku5LcPVT77SRfS/LVJH+U5Pih9zYm2ZHk/iRvHqqfleSu9t4VSdLqxyS5sdVvS7Ki175Ikuau5wzmGmD1PrVtwJlV9Srgr4CNAElOB9YCZ7QxH06yqI25ElgPrGyPvZ95MfCtqvpB4APA+7rtiSRpzroFTFV9EfjmPrXPVdWe9vJLwPK2vAa4oaqeqqoHgR3A2UlOAZZU1a1VVcC1wIVDYza35ZuAc/fObiRJkzfJczC/ANzSlpcBjwy9N91qy9ryvvVnjWmh9Tjw/TNtKMn6JFNJpnbv3n3YdkCSdGATCZgkvwnsAa7bW5phtZqlPtuY/YtVV1XVqqpatXTp0rm2K0k6BGMPmCTrgPOBt7fDXjCYmZw6tNpy4NFWXz5D/VljkiwGXsI+h+QkSZMz1oBJshp4D3BBVX136K2twNp2ZdhpDE7m315VO4Enk5zTzq9cBNw8NGZdW/4Z4AtDgSVJmrDFvT44yfXAG4ATk0wDlzG4auwYYFs7H/+lqvqlqronyRbgXgaHzi6tqmfaR13C4Iq0Yxmcs9l73uZq4GNJdjCYuazttS+SpLnrFjBV9bYZylfPsv4mYNMM9SngzBnq/wi89bn0KEnqx2/yS5K6MGAkSV0YMJKkLgwYSVIXBowkqQsDRpLUhQEjSerCgJEkdWHASJK6MGAkSV0YMJKkLgwYSVIXBowkqQsDRpLUhQEjSerCgJEkdWHASJK6MGAkSV0YMJKkLhZPugFJAys2fGas23vo8vPGuj0dfZzBSJK6MGAkSV10C5gkH02yK8ndQ7UTkmxL8kB7funQexuT7Ehyf5I3D9XPSnJXe++KJGn1Y5Lc2Oq3JVnRa18kSXPXcwZzDbB6n9oGYHtVrQS2t9ckOR1YC5zRxnw4yaI25kpgPbCyPfZ+5sXAt6rqB4EPAO/rtieSpDnrFjBV9UXgm/uU1wCb2/Jm4MKh+g1V9VRVPQjsAM5OcgqwpKpuraoCrt1nzN7Pugk4d+/sRpI0eeM+B3NyVe0EaM8ntfoy4JGh9aZbbVlb3rf+rDFVtQd4HPj+mTaaZH2SqSRTu3fvPky7IkmazZFykn+mmUfNUp9tzP7FqquqalVVrVq6dOkhtihJmotxB8xj7bAX7XlXq08Dpw6ttxx4tNWXz1B/1pgki4GXsP8hOUnShIw7YLYC69ryOuDmofradmXYaQxO5t/eDqM9meScdn7lon3G7P2snwG+0M7TSJKOAN2+yZ/keuANwIlJpoHLgMuBLUkuBh4G3gpQVfck2QLcC+wBLq2qZ9pHXcLgirRjgVvaA+Bq4GNJdjCYuazttS+SpLnrFjBV9bYDvHXuAdbfBGyaoT4FnDlD/R9pASVJOvIcKSf5JUkLjAEjSerCgJEkdWHASJK6MGAkSV0YMJKkLgwYSVIXBowkqQsDRpLUhQEjSerCgJEkdWHASJK6MGAkSV0YMJKkLgwYSVIXBowkqQsDRpLUhQEjSepipIBJst9PFkuSNJtRZzC/l+T2JP8lyfFdO5IkLQgjBUxV/Vvg7cCpwFSSP0zypq6dSZLmtZHPwVTVA8B/A94D/DvgiiRfS/LTvZqTJM1fo56DeVWSDwD3AW8Efqqqfrgtf2CuG03yq0nuSXJ3kuuTvCDJCUm2JXmgPb90aP2NSXYkuT/Jm4fqZyW5q713RZLMtRdJUh+jzmB+F7gTeHVVXVpVdwJU1aMMZjUjS7IMeCewqqrOBBYBa4ENwPaqWglsb69Jcnp7/wxgNfDhJIvax10JrAdWtsfqufQiSepn1IB5C/CHVfUPAEmel+Q4gKr62CFsdzFwbJLFwHHAo8AaYHN7fzNwYVteA9xQVU9V1YPADuDsJKcAS6rq1qoq4NqhMZKkCRs1YD4PHDv0+rhWm7Oq+gbwO8DDwE7g8ar6HHByVe1s6+wETmpDlgGPDH3EdKsta8v71veTZH2SqSRTu3fvPpS2JUlzNGrAvKCq/n7vi7Z83KFssJ1bWQOcBrwMeGGSd8w2ZIZazVLfv1h1VVWtqqpVS5cunWvLkqRDMGrAfCfJa/e+SHIW8A+HuM2fAB6sqt1V9U/Ap4AfBR5rh71oz7va+tMMLo/eazmDQ2rTbXnfuiTpCDBqwLwb+ESSv0jyF8CNwC8f4jYfBs5Jcly76utcBlenbQXWtXXWATe35a3A2iTHJDmNwcn829thtCeTnNM+56KhMZKkCVs8ykpV9ZdJXgm8gsGhqa+12cecVdVtSW5icFXaHuDLwFXAi4AtSS5mEEJvbevfk2QLcG9b/9KqeqZ93CXANQzOD93SHpKkI8BIAdO8DljRxrwmCVV17aFstKouAy7bp/wUg9nMTOtvAjbNUJ8CvE+aJB2BRgqYJB8D/hXwFWDv7GHvpcGSJO1n1BnMKuD09n0TaWJWbPjMpFuQNKJRT/LfDfyLno1IkhaWUWcwJwL3JrmdwbkSAKrqgi5dSZLmvVED5r09m5AkLTyjXqb850n+JbCyqj7f7kO26GDjJElHr1Fv1/+LwE3A77fSMuDTvZqSJM1/o57kvxR4PfAE/P8fHztp1hGSpKPaqAHzVFU9vfdFu82+lyxLkg5o1ID58yS/weA3XN4EfAL43/3akiTNd6MGzAZgN3AX8J+BzzLHX7KUJB1dRr2K7HvA/2oPSZIOatR7kT3IDOdcqurlh70jSdKCMJd7ke31Aga30j/h8LcjSVooRjoHU1V/N/T4RlV9EHhj594kSfPYqIfIXjv08nkMZjQv7tKRJGlBGPUQ2f8YWt4DPAT87GHvRpK0YIx6FdmP925EkrSwjHqI7L/O9n5Vvf/wtCNJWijmchXZ64Ct7fVPAV8EHunRlKT+xv3roA9dft5Yt6fJm8sPjr22qp4ESPJe4BNV9Z96NSZJmt9GvVXMDwBPD71+Glhx2LuRJC0YowbMx4Dbk7w3yWXAbcC1h7rRJMcnuSnJ15Lcl+RHkpyQZFuSB9rzS4fW35hkR5L7k7x5qH5Wkrvae1ckyaH2JEk6vEb9ouUm4OeBbwHfBn6+qn7rOWz3Q8AfV9UrgVcD9zG4oeb2qloJbG+vSXI6sBY4A1gNfDjJ3l/TvBJYD6xsj9XPoSdJ0mE06gwG4Djgiar6EDCd5LRD2WCSJcCPAVcDVNXTVfVtYA2wua22GbiwLa8Bbqiqp6rqQWAHcHaSU4AlVXVrVRWDGdWFSJKOCKP+ZPJlwHuAja30fODjh7jNlzO49f8fJPlyko8keSFwclXtBGjPe38xcxnPvlptutWWteV96zP1vz7JVJKp3bt3H2LbkqS5GHUG8++BC4DvAFTVoxz6rWIWA68Frqyq17TP3DDL+jOdV6lZ6vsXq66qqlVVtWrp0qVz7VeSdAhGDZin22GoAmgzjkM1DUxX1W3t9U0MAuexdtiL9rxraP1Th8YvBx5t9eUz1CVJR4BRA2ZLkt8Hjk/yi8DnOcQfH6uqvwEeSfKKVjoXuJfBlzjXtdo64Oa2vBVYm+SYdt5nJXB7O4z2ZJJz2tVjFw2NkSRN2EG/aNn+8b4ReCXwBPAK4L9X1bbnsN1fAa5L8n3AXzO4Qu15DILsYuBhBr85Q1Xdk2QLgxDaA1xaVc+0z7kEuAY4FrilPSRJR4CDBkxVVZJPV9VZwHMJleHP/ArP/hGzvc49wPqbgE0z1KeAMw9HT5Kkw2vUQ2RfSvK6rp1IkhaUUe9F9uPALyV5iMFVX2EwuXlVr8YkSfPbrAGT5Aeq6mHgJ8fUjyRpgTjYDObTDO6i/PUkn6yq/zCOpiRJ89/BzsEMf5nx5T0bkSQtLAcLmDrAsiRJszrYIbJXJ3mCwUzm2LYM/3ySf0nX7iRJ89asAVNVi2Z7X5KkA5nL7folSRqZASNJ6sKAkSR1YcBIkrowYCRJXRgwkqQuRr3Z5YJx1zceZ8WGz4xtew9dft7YtiVJRxJnMJKkLgwYSVIXBowkqQsDRpLUhQEjSerCgJEkdWHASJK6mNj3YJIsAqaAb1TV+UlOAG4EVgAPAT9bVd9q624ELgaeAd5ZVX/S6mcB1wDHAp8F3lVV/jCapLEb5/frYH58x26SM5h3AfcNvd4AbK+qlcD29pokpwNrgTOA1cCHWzgBXAmsB1a2x+rxtC5JOpiJBEyS5cB5wEeGymuAzW15M3DhUP2Gqnqqqh4EdgBnJzkFWFJVt7ZZy7VDYyRJEzapGcwHgV8HvjdUO7mqdgK055NafRnwyNB60622rC3vW5ckHQHGfg4myfnArqq6I8kbRhkyQ61mqc+0zfUMDqWxaMnSETuVpCPXuM/5HIpJnOR/PXBBkrcALwCWJPk48FiSU6pqZzv8tautPw2cOjR+OfBoqy+fob6fqroKuArgmFNWehGAJI3B2A+RVdXGqlpeVSsYnLz/QlW9A9gKrGurrQNubstbgbVJjklyGoOT+be3w2hPJjknSYCLhsZIkibsSLpd/+XAliQXAw8DbwWoqnuSbAHuBfYAl1bVM23MJfzzZcq3tIck6Qgw0YCpqj8D/qwt/x1w7gHW2wRsmqE+BZzZr0NJ0qHym/ySpC4MGElSFwaMJKkLA0aS1IUBI0nqwoCRJHVhwEiSujBgJEldHEnf5Je0gPmDXEcfZzCSpC4MGElSFwaMJKkLA0aS1IUn+TvzxKako5UzGElSFwaMJKkLA0aS1IUBI0nqwoCRJHVhwEiSujBgJEldGDCSpC78oqWkBWncX3LW/sY+g0lyapI/TXJfknuSvKvVT0iyLckD7fmlQ2M2JtmR5P4kbx6qn5XkrvbeFUky7v2RJM1sEjOYPcCvVdWdSV4M3JFkG/Afge1VdXmSDcAG4D1JTgfWAmcALwM+n+SHquoZ4EpgPfAl4LPAauCWse/RUcz/JUo6kLHPYKpqZ1Xd2ZafBO4DlgFrgM1ttc3AhW15DXBDVT1VVQ8CO4Czk5wCLKmqW6uqgGuHxkiSJmyiJ/mTrABeA9wGnFxVO2EQQsBJbbVlwCNDw6ZbbVlb3rc+03bWJ5lKMvXMdx8/nLsgSTqAiQVMkhcBnwTeXVVPzLbqDLWapb5/seqqqlpVVasWHfeSuTcrSZqziQRMkuczCJfrqupTrfxYO+xFe97V6tPAqUPDlwOPtvryGeqSpCPAJK4iC3A1cF9VvX/ora3Aura8Drh5qL42yTFJTgNWAre3w2hPJjmnfeZFQ2MkSRM2iavIXg/8HHBXkq+02m8AlwNbklwMPAy8FaCq7kmyBbiXwRVol7YryAAuAa4BjmVw9ZhXkEnSEWLsAVNV/5eZz58AnHuAMZuATTPUp4AzD193kqTDxVvFSJK6MGAkSV0YMJKkLgwYSVIXBowkqQsDRpLUhQEjSerCgJEkdWHASJK6MGAkSV1M4l5k6shfmJR0pHAGI0nqwoCRJHVhwEiSujBgJEldGDCSpC4MGElSFwaMJKkLA0aS1IUBI0nqwoCRJHVhwEiSupj3AZNkdZL7k+xIsmHS/UiSBuZ1wCRZBPxP4CeB04G3JTl9sl1JkmCeBwxwNrCjqv66qp4GbgDWTLgnSRLz/3b9y4BHhl5PA/9m35WSrAfWt5d///X3nX//GHqbyYnA305o25NwtO0vuM9Hi6Nxn18x1wHzPWAyQ632K1RdBVzVv53ZJZmqqlWT7mNcjrb9Bff5aHG07vNcx8z3Q2TTwKlDr5cDj06oF0nSkPkeMH8JrExyWpLvA9YCWyfckySJeX6IrKr2JPll4E+ARcBHq+qeCbc1m4kfphuzo21/wX0+WrjPI0jVfqcsJEl6zub7ITJJ0hHKgJEkdWHAdJbk1CR/muS+JPckedekexqXJIuSfDnJ/5l0L+OQ5PgkNyX5Wvvz/pFJ99Rbkl9tf6/vTnJ9khdMuqfDLclHk+xKcvdQ7YQk25I80J5fOskeD7cD7PNvt7/bX03yR0mOP9jnGDD97QF+rap+GDgHuPQoup3Nu4D7Jt3EGH0I+OOqeiXwahb4vidZBrwTWFVVZzK40GbtZLvq4hpg9T61DcD2qloJbG+vF5Jr2H+ftwFnVtWrgL8CNh7sQwyYzqpqZ1Xd2ZafZPCPzrLJdtVfkuXAecBHJt3LOCRZAvwYcDVAVT1dVd+ebFdjsRg4Nsli4DgW4PfQquqLwDf3Ka8BNrflzcCFY22qs5n2uao+V1V72ssvMfje4awMmDFKsgJ4DXDbZDsZiw8Cvw58b9KNjMnLgd3AH7TDgh9J8sJJN9VTVX0D+B3gYWAn8HhVfW6yXY3NyVW1Ewb/iQROmnA/4/YLwC0HW8mAGZMkLwI+Cby7qp6YdD89JTkf2FVVd0y6lzFaDLwWuLKqXgN8h4V32ORZ2nmHNcBpwMuAFyZ5x2S7Um9JfpPBof/rDrauATMGSZ7PIFyuq6pPTbqfMXg9cEGShxjc4fqNST4+2Za6mwamq2rv7PQmBoGzkP0E8GBV7a6qfwI+BfzohHsal8eSnALQnndNuJ+xSLIOOB94e43wJUoDprMkYXBc/r6qev+k+xmHqtpYVcuragWDk75fqKoF/T/bqvob4JEke+84ey5w7wRbGoeHgXOSHNf+np/LAr+wYchWYF1bXgfcPMFexiLJauA9wAVV9d1Rxhgw/b0e+DkG/4v/Snu8ZdJNqYtfAa5L8lXgXwO/NeF+umqztZuAO4G7GPx7suBuoZLkeuBW4BVJppNcDFwOvCnJA8Cb2usF4wD7/LvAi4Ft7d+x3zvo53irGElSD85gJEldGDCSpC4MGElSFwaMJKkLA0aS1IUBI0nqwoCRJHXx/wAeiPjtOuPTdgAAAABJRU5ErkJggg==\n"
+          },
+          "metadata": {
+            "needs_background": "light"
+          }
+        }
+      ],
+      "execution_count": 6,
+      "metadata": {
+        "collapsed": true,
+        "jupyter": {
+          "source_hidden": false,
+          "outputs_hidden": false
+        },
+        "nteract": {
+          "transient": {
+            "deleting": false
+          }
+        },
+        "gather": {
+          "logged": 1618319326129
+        }
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Citation\n",
+        "\n",
+        "It's good practise to cite the data using a DOI (Digital Object Identifier), see GBIF's [Citation Guidelines](https://www.gbif.org/citation-guidelines).\n",
+        "\n",
+        "GBIF have a service to create a DOI covering a subset of a cloud dataset.  We need to know the DOI of the cloud dataset, and the number of occurrences we used from each contributing dataset."
+      ],
+      "metadata": {
+        "nteract": {
+          "transient": {
+            "deleting": false
+          }
+        }
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "print(fs.cat(data_path + '/citation.txt').decode(\"unicode_escape\"))\n",
+        "\n",
+        "# This is the usage of the month graph, which only used plants:\n",
+        "some_plants.groupby(by='datasetkey')['gbifid'].count().reset_index(name='count').sort_values(['count'], ascending=False)"
+      ],
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "GBIF Occurrence Data https://doi.org/10.15468/dl.79tfrn\n",
+            "\n",
+            "For citation guidelines, including how to create a DOI for a subset of this dataset, please visit https://www.gbif.org/citation-guidelines#derivedDatasets\n",
+            "\n"
+          ]
+        },
+        {
+          "output_type": "execute_result",
+          "execution_count": 7,
+          "data": {
+            "text/plain": "                              datasetkey  count\n3   ad43e954-dd79-4986-ae34-9ccdbd8bf568  33112\n7   b124e1e0-4755-430f-9eab-894f25a9b59c  24432\n9   be9a09a9-7eb8-4f74-b4a7-e4247c580ee9   7363\n12  c1fc2df7-223b-4472-8998-70afb3b749ab   1898\n0   a8f27b2e-67a9-43cb-ad18-df43e0152c33   1731\n1   ac103da8-23c3-4d6e-891d-266923365893    463\n14  c28aed67-1d46-471c-bad1-e875d5515b59    405\n4   ad831fd0-4047-41ce-a7b0-568259f6a247    263\n11  c031f445-f0b2-4ad4-891e-45bf11730243    188\n5   ae379339-581e-4126-9fb1-ea1c1fc91412    150\n6   b0667eec-40cf-401f-858c-86df1781019b    131\n8   bb81513d-74ea-4733-b7b9-dc2dc190d367     32\n10  bed966df-9c01-4489-9627-6d4b87949473     23\n2   ac6c9e7c-6e97-47f5-a163-e21ab8c840b8      8\n13  c23c13a2-8159-4f83-be5e-cf08845b2dc1      4",
+            "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>datasetkey</th>\n      <th>count</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>3</th>\n      <td>ad43e954-dd79-4986-ae34-9ccdbd8bf568</td>\n      <td>33112</td>\n    </tr>\n    <tr>\n      <th>7</th>\n      <td>b124e1e0-4755-430f-9eab-894f25a9b59c</td>\n      <td>24432</td>\n    </tr>\n    <tr>\n      <th>9</th>\n      <td>be9a09a9-7eb8-4f74-b4a7-e4247c580ee9</td>\n      <td>7363</td>\n    </tr>\n    <tr>\n      <th>12</th>\n      <td>c1fc2df7-223b-4472-8998-70afb3b749ab</td>\n      <td>1898</td>\n    </tr>\n    <tr>\n      <th>0</th>\n      <td>a8f27b2e-67a9-43cb-ad18-df43e0152c33</td>\n      <td>1731</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>ac103da8-23c3-4d6e-891d-266923365893</td>\n      <td>463</td>\n    </tr>\n    <tr>\n      <th>14</th>\n      <td>c28aed67-1d46-471c-bad1-e875d5515b59</td>\n      <td>405</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>ad831fd0-4047-41ce-a7b0-568259f6a247</td>\n      <td>263</td>\n    </tr>\n    <tr>\n      <th>11</th>\n      <td>c031f445-f0b2-4ad4-891e-45bf11730243</td>\n      <td>188</td>\n    </tr>\n    <tr>\n      <th>5</th>\n      <td>ae379339-581e-4126-9fb1-ea1c1fc91412</td>\n      <td>150</td>\n    </tr>\n    <tr>\n      <th>6</th>\n      <td>b0667eec-40cf-401f-858c-86df1781019b</td>\n      <td>131</td>\n    </tr>\n    <tr>\n      <th>8</th>\n      <td>bb81513d-74ea-4733-b7b9-dc2dc190d367</td>\n      <td>32</td>\n    </tr>\n    <tr>\n      <th>10</th>\n      <td>bed966df-9c01-4489-9627-6d4b87949473</td>\n      <td>23</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>ac6c9e7c-6e97-47f5-a163-e21ab8c840b8</td>\n      <td>8</td>\n    </tr>\n    <tr>\n      <th>13</th>\n      <td>c23c13a2-8159-4f83-be5e-cf08845b2dc1</td>\n      <td>4</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
+          },
+          "metadata": {}
+        }
+      ],
+      "execution_count": 7,
+      "metadata": {
+        "collapsed": true,
+        "jupyter": {
+          "source_hidden": false,
+          "outputs_hidden": false
+        },
+        "nteract": {
+          "transient": {
+            "deleting": false
+          }
+        },
+        "gather": {
+          "logged": 1618319326444
+        }
+      }
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "name": "python3-azureml",
+      "language": "python",
+      "display_name": "Python 3.6 - AzureML"
+    },
+    "language_info": {
+      "name": "python",
+      "version": "3.6.9",
+      "mimetype": "text/x-python",
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "pygments_lexer": "ipython3",
+      "nbconvert_exporter": "python",
+      "file_extension": ".py"
+    },
+    "kernel_info": {
+      "name": "python3-azureml"
+    },
+    "microsoft": {
+      "host": {
+        "AzureML": {
+          "notebookHasBeenCompleted": true
+        }
+      }
+    },
+    "nteract": {
+      "version": "nteract-front-end@1.0.0"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 2
+}

--- a/data/gbif.md
+++ b/data/gbif.md
@@ -1,0 +1,124 @@
+# Global Biodiversity Information Facility (GBIF)
+
+## Overview
+
+The [Global Biodiversity Information Facility](https://www.gbif.org) (GBIF) is an international network and data infrastructure funded by the world's governments providing global data that document the occurrence of species.
+
+GBIF currently integrates datasets documenting over 1.6 billion species occurrences illustrated here.
+
+![GBIF world map](https://labs.gbif.org/~mblissett/2019/10/analytics-maps/world-2021-01-01.png)
+
+The GBIF occurrence dataset combines data from a wide array of sources including specimen-related data from natural history museums, observations from citizen science networks and environment recording schemes. While these data are constantly changing in [GBIF.org](https://www.gbif.org), periodic snapshots are taken and made available here.
+
+## Storage resources
+
+Data are stored in Parquet format files in Azure Blob Storage in the West Europe Azure region, in the following blob container:
+
+`https://ai4edataeuwest.blob.core.windows.net/gbif`
+
+Within that container, the periodic occurrence snapshots are stored in `occurrence/YYYY-MM-DD`, where `YYYY-MM-DD` corresponds to the date of the snapshot.
+
+The snapshot includes all CC-BY licensed data published through GBIF that have coordinates which passed automated quality checks.
+
+Each snapshot contains a `citation.txt` with instructions on how best to cite the data, and the data files themselves in Parquet format: `occurrence.parquet/*`.
+
+Therefore, the data files for the first snapshot are at
+
+`https://ai4edataeuwest.blob.core.windows.net/gbif/occurrence/2021-04-13/occurrence.parquet/*`
+
+and the citation information is at
+
+`https://ai4edataeuwest.blob.core.windows.net/gbif/occurrence/2021-04-13/citation.txt`
+
+The Parquet file schema is described here.
+Most field names correspond to [terms from the Darwin Core standard](https://dwc.tdwg.org/terms/), and have been interpreted by GBIF's systems to align taxonomy, location, dates etc.
+Additional information may be retrived using the [GBIF API](https://www.gbif.org/developer/summary).
+
+|              Field¹              |     Type      | Nullable | Description                   |
+|----------------------------------|---------------|----------|-------------------------------|
+| gbifid                           | BigInt        | N        | GBIF's identifier for the occurrence |
+| datasetkey                       | String (UUID) | N        | GBIF's UUID for the [dataset](https://www.gbif.org/developer/registry#datasets) containing this occurrence |
+| publishingorgkey                 | String (UUID) | N        | GBIF's UUID for the [organization](https://www.gbif.org/developer/registry#organizations) publishing this occurrence. |
+| occurrencestatus                 | String        | N        | See [dwc:occurrenceStatus](https://dwc.tdwg.org/terms/#occurrenceStatus). Either the value `PRESENT` or `ABSENT`.  **Many users will wish to filter for `PRESENT` data.** |
+| basisofrecord                    | String        | N        | See [dwc:basisOfRecord](https://dwc.tdwg.org/terms/#basisOfRecord).  One of `PRESERVED_SPECIMEN`, `FOSSIL_SPECIMEN`, `LIVING_SPECIMEN`, `OBSERVATION`, `HUMAN_OBSERVATION`, `MACHINE_OBSERVATION`, `MATERIAL_SAMPLE`, `LITERATURE`, `UNKNOWN`. |
+| kingdom                          | String        | Y        | See [dwc:kingdom](https://dwc.tdwg.org/terms/#kingdom).  This field has been aligned with the [GBIF backbone taxonomy](https://doi.org/10.15468/39omei). |
+| phylum                           | String        | Y        | See [dwc:phylum](https://dwc.tdwg.org/terms/#phylum).  This field has been aligned with the GBIF backbone taxonomy. |
+| class                            | String        | Y        | See [dwc:class](https://dwc.tdwg.org/terms/#class).  This field has been aligned with the GBIF backbone taxonomy. |
+| order                            | String        | Y        | See [dwc:order](https://dwc.tdwg.org/terms/#order).  This field has been aligned with the GBIF backbone taxonomy. |
+| family                           | String        | Y        | See [dwc:family](https://dwc.tdwg.org/terms/#family).  This field has been aligned with the GBIF backbone taxonomy. |
+| genus                            | String        | Y        | See [dwc:genus](https://dwc.tdwg.org/terms/#genus).  This field has been aligned with the GBIF backbone taxonomy. |
+| species                          | String        | Y        | See [dwc:species](https://dwc.tdwg.org/terms/#species).  This field has been aligned with the GBIF backbone taxonomy. |
+| infraspecificepithet             | String        | Y        | See [dwc:infraspecificEpithet](https://dwc.tdwg.org/terms/#infraspecificEpithet).  This field has been aligned with the GBIF backbone taxonomy. |
+| taxonrank                        | String        | Y        | See [dwc:taxonRank](https://dwc.tdwg.org/terms/#taxonRank).  This field has been aligned with the GBIF backbone taxonomy. |
+| scientificname                   | String        | Y        | See [dwc:scientificName](https://dwc.tdwg.org/terms/#scientificName).  This field has been aligned with the GBIF backbone taxonomy. |
+| verbatimscientificname           | String        | Y        | The scientific name as provided by the data publisher |
+| verbatimscientificnameauthorship | String        | Y        | The scientific name authorship provided by the data publisher. |
+| taxonkey                         | Integer       | Y        | The numeric identifier for the [taxon](https://www.gbif.org/developer/species#nameUsages) in GBIF's backbone taxonomy corresponding to `scientificname`. |
+| specieskey                       | Integer       | Y        | The numeric identifier for the taxon in GBIF's backbone taxonomy corresponding to `species`. |
+| typestatus                       | String        | Y        | See [dwc:typeStatus](https://dwc.tdwg.org/terms/#typeStatus). |
+| countrycode                      | String        | Y        | See [dwc:countryCode](https://dwc.tdwg.org/terms/#countryCode).  GBIF's interpretation has set this to an ISO 3166-2 code. |
+| locality                         | String        | Y        | See [dwc:locality](https://dwc.tdwg.org/terms/#locality). |
+| stateprovince                    | String        | Y        | See [dwc:stateProvince](https://dwc.tdwg.org/terms/#stateProvince). |
+| decimallatitude                  | Double        | Y²       | See [dwc:decimalLatitude](https://dwc.tdwg.org/terms/#decimalLatitude).  GBIF's interpretation has normalized this to a WGS84 coordinate. |
+| decimallongitude                 | Double        | Y²       | See [dwc:decimalLongitude](https://dwc.tdwg.org/terms/#decimalLongitude).  GBIF's interpretation has normalized this to a WGS84 coordinate. |
+| coordinateuncertaintyinmeters    | Double        | Y        | See [dwc:coordinateUncertaintyInMeters](https://dwc.tdwg.org/terms/#coordinateUncertaintyInMeters). |
+| coordinateprecision              | Double        | Y        | See [dwc:coordinatePrecision](https://dwc.tdwg.org/terms/#coordinatePrecision). |
+| elevation                        | Double        | Y        | See [dwc:elevation](https://dwc.tdwg.org/terms/#elevation).  If provided by the data publisher, GBIF's interpretation has normalized this value to metres. |
+| elevationaccuracy                | Double        | Y        | See [dwc:elevationAccuracy](https://dwc.tdwg.org/terms/#elevationAccuracy).  If provided by the data publisher, GBIF's interpretation has normalized this value to metres. |
+| depth                            | Double        | Y        | See [dwc:depth](https://dwc.tdwg.org/terms/#depth).  If provided by the data publisher, GBIF's interpretation has normalized this value to metres. |
+| depthaccuracy                    | Double        | Y        | See [dwc:depthAccuracy](https://dwc.tdwg.org/terms/#depthAccuracy).  If provided by the data publisher, GBIF's interpretation has normalized this value to metres. |
+| eventdate                        | String        | Y        | See [dwc:eventDate](https://dwc.tdwg.org/terms/#eventDate).  GBIF's interpretation has normalized this value to an ISO 8601 date with a local time. |
+| year                             | Integer       | Y        | See [dwc:year](https://dwc.tdwg.org/terms/#year). |
+| month                            | Integer       | Y        | See [dwc:month](https://dwc.tdwg.org/terms/#month). |
+| day                              | Integer       | Y        | See [dwc:day](https://dwc.tdwg.org/terms/#day). |
+| individualcount                  | Integer       | Y        | See [dwc:individualCount](https://dwc.tdwg.org/terms/#individualCount). |
+| establishmentmeans               | String        | Y        | See [dwc:establishmentMeans](https://dwc.tdwg.org/terms/#establishmentMeans). |
+| occurrenceid                     | String        | Y³       | See [dwc:occurrenceID](https://dwc.tdwg.org/terms/#occurrenceID). |
+| institutioncode                  | String        | Y³       | See [dwc:institutionCode](https://dwc.tdwg.org/terms/#institutionCode). |
+| collectioncode                   | String        | Y³       | See [dwc:collectionCode](https://dwc.tdwg.org/terms/#collectionCode). |
+| catalognumber                    | String        | Y³       | See [dwc:catalogNumber](https://dwc.tdwg.org/terms/#catalogNumber). |
+| recordnumber                     | String        | Y        | See [dwc:recordNumber](https://dwc.tdwg.org/terms/#recordNumber). |
+| recordedby                       | String        | Y        | See [dwc:recordedBy](https://dwc.tdwg.org/terms/#recordedBy). |
+| identifiedby                     | String        | Y        | See [dwc:identifiedBy](https://dwc.tdwg.org/terms/#identifiedBy). |
+| dateidentified                   | String        | Y        | See [dwc:dateIdentified](https://dwc.tdwg.org/terms/#dateIdentified). An ISO 8601 date. |
+| mediatype                        | String array  | N⁴       | See [dwc:mediaType](https://dwc.tdwg.org/terms/#mediaType).  May contain `StillImage`, `MovingImage` or `Sound` (from [enumeration](http://api.gbif.org/v1/enumeration/basic/MediaType), detailing whether the occurrence has this media available. |
+| issue                            | String array  | N⁴       | A list of [issues](https://gbif.github.io/gbif-api/apidocs/org/gbif/api/vocabulary/OccurrenceIssue.html) encountered by GBIF in processing this record. |
+| license                          | String        | N        | See [dwc:license](https://dwc.tdwg.org/terms/#license). Either [`CC0_1_0`](https://creativecommons.org/publicdomain/zero/1.0/) or [`CC_BY_4_0`](https://creativecommons.org/licenses/by/4.0/).  (`CC_BY_NC_4_0` records are not present in this snapshot.) |
+| rightsholder                     | String        | Y        | See [dwc:rightsHolder](https://dwc.tdwg.org/terms/#rightsHolder). |
+| lastinterpreted                  | String        | N        | The ISO 8601 date when the record was last processed by GBIF. Data are reprocessed for several reasons, including changes to the backbone taxonomy, so this date is not necessarily the date the occurrence record last changed. |
+
+¹ Field names are lower case, but in later snapshots this may change to camelCase, for consistency with Darwin Core and the GBIF API.
+
+² Occurrences without coordinates are excluded from this snapshot, although this may change in the future.
+
+³ Either `occurrenceID`, or `institutionCode` + `collectionCode` + `catalogNumber`, or both, will be present on every record.
+
+⁴ The array may be empty.
+
+Mounting instructions for Linux are [here](https://docs.microsoft.com/en-us/azure/storage/blobs/storage-how-to-mount-container-linux).
+
+
+## Sample code
+
+A preliminary Python example of accessing and querying the GBIF data is in the accompanying [sample notebook](gbif.ipynb). This example shows how to access and perform basic querying of a one file-part, and future examples will show how to run full scale analysis.
+
+
+## License and attribution
+
+This dataset is available under a [CC-BY](https://creativecommons.org/licenses/by/4.0/) license and with the GBIF [terms of use](https://www.gbif.org/terms).
+
+
+Please refer to the GBIF [citation guidelines](https://www.gbif.org/citation-guidelines). For analyses using the whole dataset please use the following citation:
+
+> GBIF.org ([Date]) GBIF Occurrence Data [DOI of dataset]
+
+For analyses where data are significantly filtered, please track the datasetKeys used and use a “[derived dataset](https://www.gbif.org/citation-guidelines#derivedDatasets)” record for citing the data.
+
+## Contact
+
+For questions about this dataset, contact [`aiforearthdatasets@microsoft.com`](mailto:aiforearthdatasets@microsoft.com?subject=gbif%20question) or [`helpdesk@gbif.org`](mailto:helpdesk@gbif.org?subject=MS%20AI4Earth%20question).
+
+
+## Notices
+
+Microsoft provides this dataset on an "as is" basis.  Microsoft makes no warranties (express or implied), guarantees, or conditions with respect to your use of the dataset.  To the extent permitted under your local law, Microsoft disclaims all liability for any damages or losses - including direct, consequential, special, indirect, incidental, or punitive - resulting from your use of this dataset.  This dataset is provided under the original terms that Microsoft received source data.


### PR DESCRIPTION
This PR adds documentation for global species occurrence data from the GBIF network, including an example notebook.  We've uploaded a dataset today to https://ai4edataeuwest.blob.core.windows.net/gbif .

The notebook needs some small changes: use without an `sas_token` (which doesn't seem to work yet), and probably removal of the `!pip` commands which I found I needed, but aren't present in the other notebooks.

I'm looking forward to seeing this!