### PR TITLE
Remove ai4e grant info from documentation files

### DIFF
--- a/data/gfs-warm-start.md
+++ b/data/gfs-warm-start.md
@@ -74,10 +74,9 @@ We also provide a read-only SAS (shared access signature) token to allow access 
 
 Mounting instructions for Linux are [here](https://docs.microsoft.com/en-us/azure/storage/blobs/storage-how-to-mount-container-linux).
 
-Large-scale processing using this dataset is best performed in the East US 2 Azure data center, where the data is stored.  If you are using GFS Warm Start data for environmental science applications, consider applying for an [AI for Earth grant](http://aka.ms/aiforearth) to support your compute requirements.
+Large-scale processing using this dataset is best performed in the East US 2 Azure data center, where the data is stored.
 
 
 ## Notices
 
 Microsoft provides this dataset on an "as is" basis.  Microsoft makes no warranties (express or implied), guarantees, or conditions with respect to your use of the dataset.  To the extent permitted under your local law, Microsoft disclaims all liability for any damages or losses - including direct, consequential, special, indirect, incidental, or punitive - resulting from your use of this dataset.  This dataset is provided under the original terms that Microsoft received source data.
-

--- a/data/ghe.md
+++ b/data/ghe.md
@@ -41,7 +41,7 @@ We also provide a read-only SAS (shared access signature) token to allow access 
 
 Mounting instructions for Linux are [here](https://docs.microsoft.com/en-us/azure/storage/blobs/storage-how-to-mount-container-linux).
 
-Large-scale processing using this dataset is best performed in the East US Azure data center, where the data is stored.  If you are using GHE data for environmental science applications, consider applying for an [AI for Earth grant](http://aka.ms/ai4egrants) to support your compute requirements.
+Large-scale processing using this dataset is best performed in the East US Azure data center, where the data is stored.
 
 
 ## Sample code
@@ -64,4 +64,3 @@ For questions about this dataset, contact [`aiforearthdatasets@microsoft.com`](m
 ## Notices
 
 Microsoft provides this dataset on an "as is" basis.  Microsoft makes no warranties (express or implied), guarantees, or conditions with respect to your use of the dataset.  To the extent permitted under your local law, Microsoft disclaims all liability for any damages or losses - including direct, consequential, special, indirect, incidental, or punitive - resulting from your use of this dataset.  This dataset is provided under the original terms that Microsoft received source data.
-

--- a/data/goes-r.md
+++ b/data/goes-r.md
@@ -77,7 +77,7 @@ https://goeseuwest.blob.core.windows.net/noaa-goes16/ABI-L2-MCMIPF/2020/003/00/O
 
 Data channels and wavelengths are described [here](https://www.ncdc.noaa.gov/data-access/satellite-data/goes-r-series-satellites/glossary).
 
-Large-scale processing using this dataset is best performed in the West Europe Azure data center, where the data is stored.  If you are using GOES data for environmental science applications, consider applying for an [AI for Earth grant](http://aka.ms/ai4egrants) to support your compute requirements.
+Large-scale processing using this dataset is best performed in the West Europe Azure data center, where the data is stored.
 
 ### East US subset
 
@@ -125,4 +125,3 @@ For questions about this dataset, contact [`aiforearthdatasets@microsoft.com`](m
 ## Notices
 
 Microsoft provides this dataset on an "as is" basis.  Microsoft makes no warranties (express or implied), guarantees, or conditions with respect to your use of the dataset.  To the extent permitted under your local law, Microsoft disclaims all liability for any damages or losses - including direct, consequential, special, indirect, incidental, or punitive - resulting from your use of this dataset.  This dataset is provided under the original terms that Microsoft received source data.
-

--- a/data/hls.md
+++ b/data/hls.md
@@ -67,7 +67,7 @@ We also provide a read-only SAS (shared access signature) token to allow access 
 
 Mounting instructions for Linux are [here](https://docs.microsoft.com/en-us/azure/storage/blobs/storage-how-to-mount-container-linux).
 
-HLS data can consume hundreds of terabytes, so large-scale processing is best performed in the East US 2 Azure data center where the images are stored. If you are using HLS data for environmental science applications, consider applying for an [AI for Earth grant](https://aka.ms/ai4egrants) to support your compute requirements.
+HLS data can consume hundreds of terabytes, so large-scale processing is best performed in the East US 2 Azure data center where the images are stored.
 
 
 ## Sample code
@@ -83,4 +83,3 @@ For questions about this dataset, contact [`aiforearthdatasets@microsoft.com`](m
 ## Notices
 
 Microsoft provides this dataset on an "as is" basis.  Microsoft makes no warranties (express or implied), guarantees, or conditions with respect to your use of the dataset.  To the extent permitted under your local law, Microsoft disclaims all liability for any damages or losses - including direct, consequential, special, indirect, incidental, or punitive - resulting from your use of this dataset.  This dataset is provided under the original terms that Microsoft received source data.
-

--- a/data/nexrad-l2.md
+++ b/data/nexrad-l2.md
@@ -35,7 +35,7 @@ We also provide a read-only SAS (shared access signature) token to allow access 
 
 Mounting instructions for Linux are [here](https://docs.microsoft.com/en-us/azure/storage/blobs/storage-how-to-mount-container-linux).
 
-NEXRAD data can consume hundreds of terabytes, so large-scale processing is best performed in the East US Azure data center, where the scans are stored.  If you are using NEXRAD data for environmental science applications, including weather forecasting, consider applying for an [AI for Earth grant](http://aka.ms/ai4egrants) to support your compute requirements.
+NEXRAD data can consume hundreds of terabytes, so large-scale processing is best performed in the East US Azure data center, where the scans are stored.
 
 
 ## Index
@@ -67,4 +67,3 @@ For questions about this dataset, contact [`aiforearthdatasets@microsoft.com`](m
 ## Notices
 
 Microsoft provides this dataset on an "as is" basis.  Microsoft makes no warranties (express or implied), guarantees, or conditions with respect to your use of the dataset.  To the extent permitted under your local law, Microsoft disclaims all liability for any damages or losses - including direct, consequential, special, indirect, incidental, or punitive - resulting from your use of this dataset.  This dataset is provided under the original terms that Microsoft received source data.
-

--- a/data/nlcd.md
+++ b/data/nlcd.md
@@ -29,7 +29,7 @@ Within that folder, data are organized according to:
 
 Images are stored in cloud-optimized GeoTIFF format.  The one and only image channel contains land cover labels according to the [NLCD legend](https://www.mrlc.gov/data/legends/national-land-cover-database-2016-nlcd2016-legend):
 
-<img src="nlcd_color_labels.jpg" style="margin-left:30px;width:300px;"/>
+<img src="https://github.com/microsoft/AIforEarthDataSets/raw/main/data/nlcd_color_labels.jpg" style="margin-left:30px;width:300px;"/>
 
 We also provide a read-only SAS (<a href="https://docs.microsoft.com/en-us/azure/storage/common/storage-sas-overview">shared access signature</a>) token to allow access to this data via, e.g., BlobFuse, which allows you to mount blob containers as drives:
 

--- a/data/nlcd.md
+++ b/data/nlcd.md
@@ -37,7 +37,7 @@ We also provide a read-only SAS (<a href="https://docs.microsoft.com/en-us/azure
 
 Mounting instructions for Linux are [here](https://docs.microsoft.com/en-us/azure/storage/blobs/storage-how-to-mount-container-linux).
 
-Large-scale processing is best performed in the West Europe Azure data center, where the data are stored.  If you are using this data for environmental science applications, consider applying for an [AI for Earth grant](http://aka.ms/ai4egrants) to support your compute requirements.
+Large-scale processing is best performed in the West Europe Azure data center, where the data are stored.
 
 
 ## Sample code

--- a/data/noaa-cdr.md
+++ b/data/noaa-cdr.md
@@ -83,7 +83,7 @@ Parentheses indicate product short names, which correspond to container names as
 
 ## Region information
 
-Large-scale processing is best performed in the East US Azure region, where the data are stored.  If you are using this data for environmental science applications, consider applying for an [AI for Earth grant](http://aka.ms/ai4egrants) to support your compute requirements.
+Large-scale processing is best performed in the East US Azure region, where the data are 
 
 
 ## Contact

--- a/data/noaa-cfs.md
+++ b/data/noaa-cfs.md
@@ -90,7 +90,7 @@ Documentation pending.
 
 ## Region information
 
-Large-scale processing is best performed in the East US Azure region, where the data are stored.  If you are using RAP data for environmental science applications, consider applying for an [AI for Earth grant](http://aka.ms/ai4egrants) to support your compute requirements.
+Large-scale processing is best performed in the East US Azure region, where the data are stored.
 
 
 ## Mounting the container

--- a/data/noaa-climatenormals.md
+++ b/data/noaa-climatenormals.md
@@ -50,7 +50,7 @@ Formats vary slightly across the daily, hourly, monthly, and annual/seasonal fol
 
 ## Region information
 
-Large-scale processing is best performed in the East US Azure region, where the data are stored.  If you are using this data for environmental science applications, consider applying for an [AI for Earth grant](http://aka.ms/ai4egrants) to support your compute requirements.
+Large-scale processing is best performed in the East US Azure region, where the data are 
 
 
 ## Contact

--- a/data/noaa-gefs.md
+++ b/data/noaa-gefs.md
@@ -71,7 +71,7 @@ Example URLs:
 
 ## Region information
 
-Large-scale processing is best performed in the East US Azure region, where the data are stored.  If you are using this data for environmental science applications, consider applying for an [AI for Earth grant](http://aka.ms/ai4egrants) to support your compute requirements.
+Large-scale processing is best performed in the East US Azure region, where the data are 
 
 
 ## Mounting the container

--- a/data/noaa-gfs.md
+++ b/data/noaa-gfs.md
@@ -40,7 +40,7 @@ File format within a folder varies by product; documentation for the primary pro
 
 ## Region information
 
-Large-scale processing is best performed in the East US Azure region, where the data are stored.  If you are using this data for environmental science applications, consider applying for an [AI for Earth grant](http://aka.ms/ai4egrants) to support your compute requirements.
+Large-scale processing is best performed in the East US Azure region, where the data are 
 
 
 ## Mounting the container

--- a/data/noaa-hrrr.md
+++ b/data/noaa-hrrr.md
@@ -47,7 +47,7 @@ A complete Python example of accessing and plotting HRRR data is available in th
 
 ## Region information
 
-Large-scale processing is best performed in the East US Azure region, where the data are stored.  If you are using HRRR data for environmental science applications, consider applying for an [AI for Earth grant](http://aka.ms/ai4egrants) to support your compute requirements.
+Large-scale processing is best performed in the East US Azure region, where the data are stored.
 
 
 ## Mounting the container

--- a/data/noaa-isd.md
+++ b/data/noaa-isd.md
@@ -22,7 +22,7 @@ Detailed documentation is available at:
 
 ## Region information
 
-Large-scale processing is best performed in the West Europe Azure region, where the data are stored.  If you are using this data for environmental science applications, consider applying for an [AI for Earth grant](http://aka.ms/ai4egrants) to support your compute requirements.
+Large-scale processing is best performed in the West Europe Azure region, where the data are 
 
 
 ## Contact

--- a/data/noaa-nclimgrid.md
+++ b/data/noaa-nclimgrid.md
@@ -61,7 +61,7 @@ Detailed documentation of the daily data .csv format is here:
 
 ## Region information
 
-Large-scale processing is best performed in the West Europe or East US Azure regions, where the data are stored.  If you are using this data for environmental science applications, consider applying for an [AI for Earth grant](http://aka.ms/ai4egrants) to support your compute requirements.
+Large-scale processing is best performed in the West Europe or East US Azure regions, where the data are 
 
 
 ## Contact

--- a/data/noaa-rap.md
+++ b/data/noaa-rap.md
@@ -42,7 +42,7 @@ For example, for the file:
 
 ## Region information
 
-Large-scale processing is best performed in the East US Azure region, where the data are stored.  If you are using RAP data for environmental science applications, consider applying for an [AI for Earth grant](http://aka.ms/ai4egrants) to support your compute requirements.
+Large-scale processing is best performed in the East US Azure region, where the data are stored.
 
 
 ## Mounting the container

--- a/data/ooi-camhd.md
+++ b/data/ooi-camhd.md
@@ -22,7 +22,7 @@ We also provide a read-only SAS (<a href="https://docs.microsoft.com/en-us/azure
 `?sv=2019-12-12&si=camhd-aod-ro&sr=c&sig=zFVfMOqa1YW9mxbEusUsKfPrKjkBFyD2YAUJficSuCo%3D`
 
 Mounting instructions for Linux are [here](https://docs.microsoft.com/en-us/azure/storage/blobs/storage-how-to-mount-container-linux).
-Large-scale processing using this dataset is best performed in the East US Azure data center, where the data are stored. Computational resources are available at [ooi.pangeo.io](https://ooi.pangeo.io/), and if you are using CamHD data for environmental science applications, you may also consider applying for an [AI for Earth grant](http://aka.ms/ai4egrants) to support your compute requirements.
+Large-scale processing using this dataset is best performed in the East US Azure data center, where the data are stored. Computational resources are available at [ooi.pangeo.io](https://ooi.pangeo.io/).
 
 
 ## Sample code
@@ -46,4 +46,3 @@ For questions about this dataset, contact [`aiforearthdatasets@microsoft.com`](m
 ## Notices
 
 Microsoft provides this dataset on an "as is" basis.  Microsoft makes no warranties (express or implied), guarantees, or conditions with respect to your use of the dataset.  To the extent permitted under your local law, Microsoft disclaims all liability for any damages or losses - including direct, consequential, special, indirect, incidental, or punitive - resulting from your use of this dataset.  This dataset is provided under the original terms that Microsoft received source data.
-

--- a/data/sentinel-1-slc.md
+++ b/data/sentinel-1-slc.md
@@ -60,7 +60,7 @@ Scenes older than 90 days are stored in the same container, but have been retire
 
 ## Region information
 
-Large-scale processing is best performed in the West Europe Azure region, where the images are stored.  If you are using Sentinel-1 data for environmental science applications, consider applying for an [AI for Earth grant](http://aka.ms/ai4egrants) to support your compute requirements.
+Large-scale processing is best performed in the West Europe Azure region, where the images are stored.
 
 
 ## Contact
@@ -71,4 +71,3 @@ For questions about this dataset, contact [`aiforearthdatasets@microsoft.com`](m
 ## Notices
 
 Microsoft provides this dataset on an "as is" basis.  Microsoft makes no warranties (express or implied), guarantees, or conditions with respect to your use of the dataset.  To the extent permitted under your local law, Microsoft disclaims all liability for any damages or losses - including direct, consequential, special, indirect, incidental, or punitive - resulting from your use of this dataset.  This dataset is provided under the original terms that Microsoft received source data.
-

--- a/data/sentinel-3.md
+++ b/data/sentinel-3.md
@@ -180,7 +180,7 @@ A complete Python example of accessing and plotting Sentinel-3 data is available
 
 ## Region information
 
-Large-scale processing is best performed in the West Europe Azure region, where the images are stored.  If you are using Sentinel-3 data for environmental science applications, consider applying for an [AI for Earth grant](http://aka.ms/ai4egrants) to support your compute requirements.
+Large-scale processing is best performed in the West Europe Azure region, where the images are stored.
 
 ## Pretty picture
 
@@ -195,4 +195,3 @@ For questions about this dataset, contact [`aiforearthdatasets@microsoft.com`](m
 ## Notices
 
 Microsoft provides this dataset on an "as is" basis.  Microsoft makes no warranties (express or implied), guarantees, or conditions with respect to your use of the dataset.  To the extent permitted under your local law, Microsoft disclaims all liability for any damages or losses - including direct, consequential, special, indirect, incidental, or punitive - resulting from your use of this dataset.  This dataset is provided under the original terms that Microsoft received source data.
-

--- a/data/sentinel-5p.md
+++ b/data/sentinel-5p.md
@@ -79,7 +79,7 @@ A complete Python example of accessing and plotting Sentinel-5P data is availabl
 
 ## Region information
 
-Large-scale processing is best performed in the West Europe Azure region, where the images are stored.  If you are using Sentinel-5P data for environmental science applications, consider applying for an [AI for Earth grant](http://aka.ms/ai4egrants) to support your compute requirements.
+Large-scale processing is best performed in the West Europe Azure region, where the images are stored.
 
 
 ## Pretty picture
@@ -95,4 +95,3 @@ For questions about this dataset, contact [`aiforearthdatasets@microsoft.com`](m
 ## Notices
 
 Microsoft provides this dataset on an "as is" basis.  Microsoft makes no warranties (express or implied), guarantees, or conditions with respect to your use of the dataset.  To the extent permitted under your local law, Microsoft disclaims all liability for any damages or losses - including direct, consequential, special, indirect, incidental, or punitive - resulting from your use of this dataset.  This dataset is provided under the original terms that Microsoft received source data.
-

--- a/storage-docs/forest-inventory-and-analysis-storage.md
+++ b/storage-docs/forest-inventory-and-analysis-storage.md
@@ -75,4 +75,4 @@ We also provide a read-only SAS (<a href="https://docs.microsoft.com/en-us/azure
 
 Mounting instructions for Linux are [here](https://docs.microsoft.com/en-us/azure/storage/blobs/storage-how-to-mount-container-linux).
 
-Large-scale processing is best performed in the West Europe Azure data center, where the data are stored.  If you are using this data for environmental science applications, consider applying for an [AI for Earth grant](http://aka.ms/ai4egrants) to support your compute requirements.
+Large-scale processing is best performed in the West Europe Azure data center, where the data are 

--- a/storage-docs/goes-r-storage.md
+++ b/storage-docs/goes-r-storage.md
@@ -36,7 +36,7 @@ https://goeseuwest.blob.core.windows.net/noaa-goes16/ABI-L2-MCMIPF/2020/003/00/O
 
 Data channels and wavelengths are described [here](https://www.ncdc.noaa.gov/data-access/satellite-data/goes-r-series-satellites/glossary).
 
-Large-scale processing using this dataset is best performed in the West Europe Azure data center, where the data is stored.  If you are using GOES data for environmental science applications, consider applying for an [AI for Earth grant](http://aka.ms/ai4egrants) to support your compute requirements.
+Large-scale processing using this dataset is best performed in the West Europe Azure data center, where the data is stored.
 
 ### East US subset
 

--- a/storage-docs/hgb-storage.md
+++ b/storage-docs/hgb-storage.md
@@ -15,4 +15,4 @@ We also provide a read-only SAS (<a href="https://docs.microsoft.com/en-us/azure
 
 Mounting instructions for Linux are [here](https://docs.microsoft.com/en-us/azure/storage/blobs/storage-how-to-mount-container-linux).
 
-Large-scale processing is best performed in the West Europe Azure data center, where the data are stored.  If you are using this data for environmental science applications, consider applying for an [AI for Earth grant](http://aka.ms/ai4egrants) to support your compute requirements.
+Large-scale processing is best performed in the West Europe Azure data center, where the data are 

--- a/storage-docs/mtbs-storage.md
+++ b/storage-docs/mtbs-storage.md
@@ -18,4 +18,4 @@ We also provide a read-only SAS (<a href="https://docs.microsoft.com/en-us/azure
 
 Mounting instructions for Linux are [here](https://docs.microsoft.com/en-us/azure/storage/blobs/storage-how-to-mount-container-linux).
 
-Large-scale processing is best performed in the West Europe Azure data center, where the data are stored.  If you are using this data for environmental science applications, consider applying for an [AI for Earth grant](http://aka.ms/ai4egrants) to support your compute requirements.
+Large-scale processing is best performed in the West Europe Azure data center, where the data are 

--- a/storage-docs/naip-storage.md
+++ b/storage-docs/naip-storage.md
@@ -39,7 +39,7 @@ We also provide a read-only SAS (<a href="https://docs.microsoft.com/en-us/azure
 
 Mounting instructions for Linux are [here](https://docs.microsoft.com/en-us/azure/storage/blobs/storage-how-to-mount-container-linux).
 
-NAIP data can consume hundreds of terabytes, so large-scale processing is best performed in the West Europe Azure data center, where the images are stored.  If you are using NAIP data for environmental science applications, consider applying for an [AI for Earth grant](http://aka.ms/ai4egrants) to support your compute requirements.
+NAIP data can consume hundreds of terabytes, so large-scale processing is best performed in the West Europe Azure data center, where the images are stored.
 
 A copy of NAIP is also available in the East US Azure region, and will be maintained there until at least the end of 2021, but we encourage users to migrate to the West Europe copy.  The East US data is in the following container:
 

--- a/storage-docs/terraclimate-storage.md
+++ b/storage-docs/terraclimate-storage.md
@@ -29,4 +29,4 @@ We also provide a read-only SAS (<a href="https://docs.microsoft.com/en-us/azure
 
 Mounting instructions for Linux are [here](https://docs.microsoft.com/en-us/azure/storage/blobs/storage-how-to-mount-container-linux).
 
-Large-scale processing is best performed in the West Europe Azure data center, where the data are stored.  If you are using this data for environmental science applications, consider applying for an [AI for Earth grant](http://aka.ms/ai4egrants) to support your compute requirements.
+Large-scale processing is best performed in the West Europe Azure data center, where the data are 


### PR DESCRIPTION
These markdown files may appear on the Planetary Computer catalog.
Remove references to the grant program which is no longer accepting
submissions.